### PR TITLE
fix(frontend): replace broken shared-ui hero layout

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -9,7 +9,7 @@ const App = () => {
     <AppProvider>
       <Header />
       <main className="px-2 sm:px-8">
-        <div className="flex min-h-[90vh] flex-col justify-center">
+        <div className="mt-12 flex min-h-[90vh] flex-col md:mt-0 md:justify-center">
           <Hero />
         </div>
         <FAQ />

--- a/packages/frontend/src/components/Hero/Hero.tsx
+++ b/packages/frontend/src/components/Hero/Hero.tsx
@@ -1,15 +1,19 @@
-import { Hero as HeroComponent } from '@sifi/shared-ui';
 import { CreateSwap } from '../CreateSwap/CreateSwap';
 
 const Hero = () => (
-  <HeroComponent
-    title="On-Chain Swap"
-    body="We'll find the optimal route for your swap. You get the best price. It's Sifi."
-  >
-    <div className="flex h-full w-full max-w-[27rem] flex-col justify-center">
-      <CreateSwap />
+  <div className="mx-auto flex w-full max-w-[67rem] flex-wrap justify-center px-4 py-4 sm:px-8 lg:px-16">
+    <div className="w-full flex-col items-center justify-center md:w-[50%] md:pb-16">
+      <h1 className="text-flashbang-white font-display mb-4 text-center text-[1.875rem] sm:text-[2.25rem] md:text-[3rem]">
+        On-Chain Swap
+      </h1>
+      <div className="border-darker-gray mx-auto mb-4 max-w-[27rem] border-b-[1px]">
+        <CreateSwap />
+      </div>
+      <p className="text-smoke font-text mx-auto text-left text-base font-light md:max-w-[380px]">
+        {`We'll find the optimal route for your swap. You get the best price. It's Sifi.`}
+      </p>
     </div>
-  </HeroComponent>
+  </div>
 );
 
 export { Hero };


### PR DESCRIPTION
This is an issue with the current version of shared-ui we are using here.

Upgrading to the latest version is a big job as we have changed a lot in that time.

 - Temporarily remove shared-ui Hero component, replace with custom containers.

![image](https://github.com/sideshiftfi/sifi/assets/112887817/986d746d-2791-48f7-aba6-daa7d83ebb68)
![image](https://github.com/sideshiftfi/sifi/assets/112887817/f938898f-bf2b-42c6-a354-9aaeea3b8238)


Closes #109 