### PR TITLE
feat(hardhat): add foundry to hardhat project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
       - name: Build
         run: pnpm build
 
@@ -55,3 +58,9 @@ jobs:
           RPC_URL: ${{ secrets.MAINNET_RPC_URL }}
         if: ${{ env.MAINNET_RPC_URL != null }}
         run: pnpm -C packages/hardhat test
+
+      - name: Test foundry
+        env:
+          RPC_URL: ${{ secrets.MAINNET_RPC_URL }}
+        if: ${{ env.MAINNET_RPC_URL != null }}
+        run: pnpm -C packages/hardhat forge test -vv

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "packages/hardhat/lib/forge-std"]
+	path = packages/hardhat/lib/forge-std
+	url = https://github.com/foundry-rs/forge-std

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -34,5 +34,6 @@
     "overrideConfigFile": ".eslintrc.vscode.json"
   },
   "vsicons.presets.nestjs": true,
-  "files.insertFinalNewline": true
+  "files.insertFinalNewline": true,
+  "solidity.monoRepoSupport": true
 }

--- a/packages/hardhat/foundry.toml
+++ b/packages/hardhat/foundry.toml
@@ -1,0 +1,7 @@
+[profile.default]
+src = 'contracts'
+out = 'out'
+libs = ['node_modules', 'lib', '../../node_modules']
+test = 'test'
+cache_path  = 'cache_forge'
+allow_paths = ["../../node_modules"]

--- a/packages/hardhat/hardhat.config.ts
+++ b/packages/hardhat/hardhat.config.ts
@@ -1,3 +1,4 @@
+import '@nomicfoundation/hardhat-foundry';
 import '@nomicfoundation/hardhat-toolbox';
 import 'hardhat-deploy';
 import * as dotenv from 'dotenv';

--- a/packages/hardhat/package.json
+++ b/packages/hardhat/package.json
@@ -16,6 +16,7 @@
   "devDependencies": {
     "@nomicfoundation/hardhat-chai-matchers": "^2.0.1",
     "@nomicfoundation/hardhat-ethers": "^3.0.4",
+    "@nomicfoundation/hardhat-foundry": "^1.0.3",
     "@nomicfoundation/hardhat-toolbox": "^3.0.0",
     "@openzeppelin/contracts": "4.9.3",
     "@uniswap/v2-periphery": "1.1.0-beta.0",

--- a/packages/hardhat/remappings.txt
+++ b/packages/hardhat/remappings.txt
@@ -1,0 +1,3 @@
+ds-test/=lib/forge-std/lib/ds-test/src/
+forge-std/=lib/forge-std/src/
+@openzeppelin/=node_modules/@openzeppelin/

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,6 +177,9 @@ importers:
       '@nomicfoundation/hardhat-ethers':
         specifier: ^3.0.4
         version: 3.0.4(ethers@6.7.0)(hardhat@2.17.1)
+      '@nomicfoundation/hardhat-foundry':
+        specifier: ^1.0.3
+        version: 1.0.3(hardhat@2.17.1)
       '@nomicfoundation/hardhat-toolbox':
         specifier: ^3.0.0
         version: 3.0.0(@nomicfoundation/hardhat-chai-matchers@2.0.1)(@nomicfoundation/hardhat-ethers@3.0.4)(@nomicfoundation/hardhat-network-helpers@1.0.8)(@nomicfoundation/hardhat-verify@1.1.0)(@typechain/ethers-v6@0.4.3)(@typechain/hardhat@8.0.3)(@types/chai@4.3.5)(@types/mocha@10.0.1)(@types/node@18.11.19)(chai@4.3.7)(ethers@6.7.0)(hardhat-gas-reporter@1.0.9)(hardhat@2.17.1)(solidity-coverage@0.8.4)(ts-node@10.9.1)(typechain@8.3.1)(typescript@4.9.5)
@@ -2954,6 +2957,15 @@ packages:
       lodash.isequal: 4.5.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@nomicfoundation/hardhat-foundry@1.0.3(hardhat@2.17.1):
+    resolution: {integrity: sha512-Fr5fx9q2lKw1Pv+iVpPfGp9e4go/hb2OpahOGGw8rM3sdUR15v+pms1rAiy9Q+IJ4r98wcZrtPy9kJ64GPulsA==}
+    peerDependencies:
+      hardhat: ^2.12.6
+    dependencies:
+      chalk: 2.4.2
+      hardhat: 2.17.1(ts-node@10.9.1)(typescript@4.9.5)
     dev: true
 
   /@nomicfoundation/hardhat-network-helpers@1.0.8(hardhat@2.17.1):


### PR DESCRIPTION
Add Foundry to `./packages/hardhat` for extensive testing.

# prerequisites:
- add foundry to machine if not installed:
```
curl -L https://foundry.paradigm.xyz | bash
``` 

- check for install
```
forge --version
```

# usage:
- running tests located inside `./packages/hardhat/test/foundry/` 
```
forge test
``` 
- compile files located inside `./packages/hardhat/contracts/`
```
forge build
```

merge #120 first