### PR TITLE
feat(frontend): add success Toasts

### DIFF
--- a/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
+++ b/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
@@ -4,7 +4,7 @@ import { useAccount, useSigner } from 'wagmi';
 import { showToast, ShiftInput } from '@sifi/shared-ui';
 import { useTokens } from '../../hooks/useTokens';
 import { useSifi } from '../../providers/SDKProvider';
-import { formatTokenAmount, getTokenBySymbol, parseErrorMessage } from '../../utils';
+import { formatTokenAmount, getEvmTxUrl, getTokenBySymbol, parseErrorMessage } from '../../utils';
 import { SwapFormKey, SwapFormKeyHelper } from '../../providers/SwapFormProvider';
 import { useCullQueries } from '../../hooks/useCullQueries';
 import { CreateSwapButtons } from '../CreateSwapButtons/CreateSwapButtons';
@@ -62,6 +62,23 @@ const CreateSwap = () => {
       },
       onSettled: () => {
         setIsLoading(false);
+      },
+      onSuccess: async tx => {
+        const txHash = tx.hash;
+        const explorerLink = getEvmTxUrl('ethereum', txHash);
+
+        showToast({
+          text: 'Your swap has been confirmed. Please stand by.',
+          type: 'info',
+        });
+
+        await tx.wait();
+
+        showToast({
+          type: 'success',
+          text: 'Your swap has confirmed. It may take a while until it confirms on the blockchain.',
+          ...(explorerLink ? { link: { text: 'View Transaction', href: explorerLink } } : {}),
+        });
       },
     }
   );

--- a/packages/frontend/src/utils/evm.ts
+++ b/packages/frontend/src/utils/evm.ts
@@ -1,0 +1,32 @@
+const getEvmTxUrl = (network: string, txid: string): string | undefined => {
+  switch (network) {
+    case 'ethereum':
+      return `https://etherscan.io/tx/${txid}`;
+    case 'avax':
+      return `https://snowtrace.io/tx/${txid}`;
+    case 'bsc':
+      return `https://bscscan.com/tx/${txid}`;
+    case 'polygon':
+      return `https://polygonscan.com/tx/${txid}`;
+    case 'etc':
+      return `http://gastracker.io/tx/${txid}`;
+    case 'fantom':
+      return `https://ftmscan.com/tx/${txid}`;
+    case 'arbitrum':
+      return `https://arbiscan.io/tx/${txid}`;
+    case 'optimism':
+      return `https://optimistic.etherscan.io/tx/${txid}`;
+    case 'smartbch':
+      return `https://smartscan.cash/transaction/${txid}`;
+    case 'cronos':
+      return `https://cronoscan.com/tx/${txid}`;
+    case 'arbitrumnova':
+      return `https://nova.arbiscan.io/tx/${txid}`;
+    case 'zksyncera':
+      return `https://explorer.zksync.io/tx/${txid}`;
+    default:
+      return undefined;
+  }
+};
+
+export { getEvmTxUrl };

--- a/packages/frontend/src/utils/index.ts
+++ b/packages/frontend/src/utils/index.ts
@@ -4,3 +4,4 @@ export * from './tokens';
 export * from './queries';
 export * from './api';
 export * from './parseErrorMessage';
+export * from './evm';


### PR DESCRIPTION
- Adds 2 toasts to communicate successful swaps.
- Adds `getEvmTxUrl` helper. I've left in other EVM chains in case we'd like to expand in the future.
- TX link works correctly

<img width="1278" alt="image" src="https://github.com/sideshiftfi/sifi/assets/128667801/20c9524d-e63a-4ffe-b196-e228f11d7a8d">

<img width="1272" alt="image" src="https://github.com/sideshiftfi/sifi/assets/128667801/9537ee2c-07c3-405b-b5e7-c0ae8fd4c3c7">

Closes #112.