### PR TITLE
fix(frontend): approve button

### DIFF
--- a/packages/frontend/src/components/CreateSwapButtons/CreateSwapButtons.tsx
+++ b/packages/frontend/src/components/CreateSwapButtons/CreateSwapButtons.tsx
@@ -23,7 +23,7 @@ const CreateSwapButtons = ({ isLoading }: { isLoading: boolean }) => {
   const { chain } = useNetwork();
   const { tokens } = useTokens();
   const { isFetching: isApproving } = useApprove();
-  const { allowance, isAllowanceAboveMinumum, isFetching: isFetchingAllowance } = useAllowance();
+  const { allowance, isAllowanceAboveFromAmount, isFetching: isFetchingAllowance } = useAllowance();
   const [fromTokenSymbol, fromAmount] = useWatch({
     name: [SwapFormKey.FromToken, SwapFormKey.FromAmount],
   });
@@ -40,15 +40,15 @@ const CreateSwapButtons = ({ isLoading }: { isLoading: boolean }) => {
 
   const showApproveButton =
     Boolean(
-      !!quote && !!allowance && !isAllowanceAboveMinumum && !isFromEthereum && hasSufficientBalance
+      !!quote &&
+        !!allowance &&
+        !isAllowanceAboveFromAmount &&
+        !isFromEthereum &&
+        hasSufficientBalance
     ) || isApproving;
 
   const isShiftButtonDisabled =
-    !isConnected ||
-    // TODO: Temporary until the approve button is fixed
-    // showApproveButton ||
-    !fromAmount ||
-    !hasSufficientBalance;
+    !isConnected || showApproveButton || !fromAmount || !hasSufficientBalance;
 
   const getShiftButtonLabel = () => {
     if (!fromAmount) return 'Enter an amount';

--- a/packages/frontend/src/hooks/useAllowance.tsx
+++ b/packages/frontend/src/hooks/useAllowance.tsx
@@ -39,7 +39,7 @@ const useAllowance = () => {
 
   // TODO: Display errors in a toast
 
-  const fromAmountInWei = ethers.utils.parseUnits(fromAmount, fromToken?.decimals);
+  const fromAmountInWei = ethers.utils.parseUnits(fromAmount || '0', fromToken?.decimals);
   const isAllowanceAboveFromAmount = allowance?.gt(fromAmountInWei);
   const isAllowanceAboveMinimum = allowance?.gt(ethers.BigNumber.from(MIN_ALLOWANCE));
 

--- a/packages/frontend/src/hooks/useAllowance.tsx
+++ b/packages/frontend/src/hooks/useAllowance.tsx
@@ -14,8 +14,8 @@ const useAllowance = () => {
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const approveAddress = quote?.approveAddress as `0x${string}`;
 
-  const [fromTokenSymbol] = useWatch({
-    name: [SwapFormKey.FromToken],
+  const [fromTokenSymbol, fromAmount] = useWatch({
+    name: [SwapFormKey.FromToken, SwapFormKey.FromAmount],
   });
 
   const fromToken = getTokenBySymbol(fromTokenSymbol, tokens);
@@ -37,9 +37,13 @@ const useAllowance = () => {
     staleTime: Infinity,
   });
 
-  const isAllowanceAboveMinumum = allowance?.gt(ethers.BigNumber.from(MIN_ALLOWANCE));
+  // TODO: Display errors in a toast
 
-  return { allowance, isAllowanceAboveMinumum, ...rest };
+  const fromAmountInWei = ethers.utils.parseUnits(fromAmount, fromToken?.decimals);
+  const isAllowanceAboveFromAmount = allowance?.gt(fromAmountInWei);
+  const isAllowanceAboveMinimum = allowance?.gt(ethers.BigNumber.from(MIN_ALLOWANCE));
+
+  return { allowance, isAllowanceAboveMinimum, isAllowanceAboveFromAmount, ...rest };
 };
 
 export { useAllowance };

--- a/packages/frontend/src/hooks/useApprove.tsx
+++ b/packages/frontend/src/hooks/useApprove.tsx
@@ -29,6 +29,8 @@ const useApprove = () => {
     if (!approveAddress) throw new Error('Approval address is missing');
     if (!tokenContract) throw new Error('Token contract is missing');
 
+    // TODO: Handle case when account already has allowance but it's not sufficient
+
     const tx = await tokenContract.functions.approve(approveAddress, BigNumber.from(MAX_ALLOWANCE));
 
     // Wagmi's contract expects to return [ContractTransaction],


### PR DESCRIPTION
Re-enables the approve button and updates the comparison logic. 

Not bug free. We certainly need to address situations when the user needs to approve again. This is a separate matter, as it might require a good way of communicating this to the user.