### PR TITLE
refactor(frontend): use absolute imports

### DIFF
--- a/packages/frontend/src/components/ConnectWallet/ConnectWallet.tsx
+++ b/packages/frontend/src/components/ConnectWallet/ConnectWallet.tsx
@@ -1,10 +1,10 @@
 import { Dialog, Transition } from '@headlessui/react';
 import { type FunctionComponent, useState, Fragment, useEffect } from 'react';
 import { showToast, WalletOption } from '@sifi/shared-ui';
+import useConnectWallet from 'src/hooks/useConnectWallet';
+import closeIcon from 'src/assets/icons/close.svg';
+import { type SupportedWallet } from 'src/connectors';
 import { Button } from '../Button';
-import useConnectWallet from '../../hooks/useConnectWallet';
-import closeIcon from '../../assets/icons/close.svg';
-import { type SupportedWallet } from '../../connectors';
 
 const supportedWallets: SupportedWallet[] = ['metamask', 'coinbase', 'walletconnect'];
 

--- a/packages/frontend/src/components/CreateSwap/CreateSwap.stories.tsx
+++ b/packages/frontend/src/components/CreateSwap/CreateSwap.stories.tsx
@@ -3,7 +3,7 @@ import { StoryFn, Meta } from '@storybook/react';
 import isChromatic from 'chromatic/isChromatic';
 import { CreateSwap } from './CreateSwap';
 import { MockWagmiDecorator } from '../../../.storybook/decorators/wagmiDecorator';
-import { baseUrl } from '../../utils';
+import { baseUrl } from 'src/utils';
 
 export default {
   title: 'Components/CreateSwap',

--- a/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
+++ b/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
@@ -2,16 +2,16 @@ import { useEffect, useState } from 'react';
 import { useWatch, useForm, useFormContext } from 'react-hook-form';
 import { useAccount, useSigner } from 'wagmi';
 import { showToast, ShiftInput } from '@sifi/shared-ui';
-import { useTokens } from '../../hooks/useTokens';
-import { useSifi } from '../../providers/SDKProvider';
-import { formatTokenAmount, getEvmTxUrl, getTokenBySymbol, parseErrorMessage } from '../../utils';
-import { SwapFormKey, SwapFormKeyHelper } from '../../providers/SwapFormProvider';
-import { useCullQueries } from '../../hooks/useCullQueries';
-import { CreateSwapButtons } from '../CreateSwapButtons/CreateSwapButtons';
-import { useQuote } from '../../hooks/useQuote';
-import { TokenSelector, useTokenSelector } from '../TokenSelector';
-import { useTokenBalance } from '../../hooks/useTokenBalance';
+import { useTokens } from 'src/hooks/useTokens';
+import { useTokenBalance } from 'src/hooks/useTokenBalance';
 import { useMutation } from '@tanstack/react-query';
+import { useSifi } from 'src/providers/SDKProvider';
+import { formatTokenAmount, getEvmTxUrl, getTokenBySymbol, parseErrorMessage } from 'src/utils';
+import { SwapFormKey, SwapFormKeyHelper } from 'src/providers/SwapFormProvider';
+import { useCullQueries } from 'src/hooks/useCullQueries';
+import { useQuote } from 'src/hooks/useQuote';
+import { CreateSwapButtons } from '../CreateSwapButtons/CreateSwapButtons';
+import { TokenSelector, useTokenSelector } from '../TokenSelector';
 
 const CreateSwap = () => {
   useCullQueries('quote');

--- a/packages/frontend/src/components/CreateSwapButtons/ApproveButton.tsx
+++ b/packages/frontend/src/components/CreateSwapButtons/ApproveButton.tsx
@@ -1,8 +1,8 @@
 import { showToast } from '@sifi/shared-ui';
 import { useWatch } from 'react-hook-form';
-import { useApprove } from '../../hooks/useApprove';
-import { useAllowance } from '../../hooks/useAllowance';
-import { SwapFormKey } from '../../providers/SwapFormProvider';
+import { useApprove } from 'src/hooks/useApprove';
+import { useAllowance } from 'src/hooks/useAllowance';
+import { SwapFormKey } from 'src/providers/SwapFormProvider';
 import { Button } from '../Button';
 
 const ApproveButton = () => {

--- a/packages/frontend/src/components/CreateSwapButtons/CreateSwapButtons.tsx
+++ b/packages/frontend/src/components/CreateSwapButtons/CreateSwapButtons.tsx
@@ -1,19 +1,19 @@
 import { useWatch } from 'react-hook-form';
 import { useAccount, useNetwork } from 'wagmi';
 import { ethers } from 'ethers';
-import { useCullQueries } from '../../hooks/useCullQueries';
-import { Button } from '../Button';
-import { ConnectWallet } from '../ConnectWallet/ConnectWallet';
-import { useAllowance } from '../../hooks/useAllowance';
+import { useCullQueries } from 'src/hooks/useCullQueries';
+import { useAllowance } from 'src/hooks/useAllowance';
+import { useApprove } from 'src/hooks/useApprove';
+import { useTokens } from 'src/hooks/useTokens';
+import { useQuote } from 'src/hooks/useQuote';
+import { SwapFormKey } from 'src/providers/SwapFormProvider';
+import { getTokenBySymbol } from 'src/utils';
+import { ETH_CONTRACT_ADDRESS } from 'src/constants';
+import { useTokenBalance } from 'src/hooks/useTokenBalance';
 import { ApproveButton } from './ApproveButton';
 import { SwitchNetworkButton } from './SwitchNetworkButton';
-import { useApprove } from '../../hooks/useApprove';
-import { useTokens } from '../../hooks/useTokens';
-import { useQuote } from '../../hooks/useQuote';
-import { SwapFormKey } from '../../providers/SwapFormProvider';
-import { getTokenBySymbol } from '../../utils';
-import { ETH_CONTRACT_ADDRESS } from '../../constants';
-import { useTokenBalance } from '../../hooks/useTokenBalance';
+import { Button } from '../Button';
+import { ConnectWallet } from '../ConnectWallet/ConnectWallet';
 
 const CreateSwapButtons = ({ isLoading }: { isLoading: boolean }) => {
   useCullQueries('routes');

--- a/packages/frontend/src/components/CreateSwapButtons/SwitchNetworkButton.tsx
+++ b/packages/frontend/src/components/CreateSwapButtons/SwitchNetworkButton.tsx
@@ -1,9 +1,9 @@
 import { useWatch } from 'react-hook-form';
 import { useSwitchNetwork } from 'wagmi';
-import { useTokens } from '../../hooks/useTokens';
-import { SwapFormKey } from '../../providers/SwapFormProvider';
+import { useTokens } from 'src/hooks/useTokens';
+import { SwapFormKey } from 'src/providers/SwapFormProvider';
+import { getTokenBySymbol } from 'src/utils';
 import { Button } from '../Button';
-import { getTokenBySymbol } from '../../utils';
 
 const SwitchNetworkButton = () => {
   const { switchNetwork, isLoading: isSwitchingNetwork } = useSwitchNetwork();

--- a/packages/frontend/src/components/FAQ/FAQ.tsx
+++ b/packages/frontend/src/components/FAQ/FAQ.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent } from 'react';
 import { Accordion } from '@sifi/shared-ui';
-import layersIcon from '../../assets/layers.svg';
-import linkIcon from '../../assets/link.svg';
+import layersIcon from 'src/assets/layers.svg';
+import linkIcon from 'src/assets/link.svg';
 
 const items = {
   exchange: [

--- a/packages/frontend/src/components/Footer/Footer.tsx
+++ b/packages/frontend/src/components/Footer/Footer.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent } from 'react';
 import { Footer as FooterComponent } from '@sifi/shared-ui';
-import logo from '../../assets/logo.svg';
+import logo from 'src/assets/logo.svg';
 
 const Footer: FunctionComponent = () => {
   return (

--- a/packages/frontend/src/components/Header/Header.tsx
+++ b/packages/frontend/src/components/Header/Header.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent } from 'react';
 import { Navbar } from '@sifi/shared-ui';
-import logo from '../../assets/logo.svg';
+import logo from 'src/assets/logo.svg';
 import HeaderMenu from '../HeaderMenu/HeaderMenu';
 
 const Header: FunctionComponent = () => {

--- a/packages/frontend/src/components/HeaderMenu/HeaderMenu.tsx
+++ b/packages/frontend/src/components/HeaderMenu/HeaderMenu.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent } from 'react';
 import { Menu } from '@sifi/shared-ui';
 import { useAccount, useDisconnect, useEnsName, useNetwork } from 'wagmi';
-import { formatAddress, formatEnsName } from '../../utils';
+import { formatAddress, formatEnsName } from 'src/utils';
 
 const HeaderMenu: FunctionComponent = () => {
   const { address, isConnected } = useAccount();

--- a/packages/frontend/src/components/Input/Input.stories.tsx
+++ b/packages/frontend/src/components/Input/Input.stories.tsx
@@ -1,5 +1,5 @@
 import { StoryFn, Meta } from '@storybook/react';
-import searchIcon from '../../assets/search.svg';
+import searchIcon from 'src/assets/search.svg';
 import { Input } from './Input';
 
 export default {

--- a/packages/frontend/src/components/TokenSelector/TokenSelector.tsx
+++ b/packages/frontend/src/components/TokenSelector/TokenSelector.tsx
@@ -2,10 +2,10 @@ import { FunctionComponent, useMemo } from 'react';
 import { useAccount } from 'wagmi';
 import { useFormContext } from 'react-hook-form';
 import { CoinSelector } from '@sifi/shared-ui';
-import { SwapFormKeyHelper, SwapFormType } from '../../providers/SwapFormProvider';
-import { useTokens } from '../../hooks/useTokens';
-import { formatTokenAmount, getTokenBySymbol } from '../../utils';
-import { useWalletBalance } from '../../hooks/useWalletBalance';
+import { SwapFormKeyHelper, SwapFormType } from 'src/providers/SwapFormProvider';
+import { useTokens } from 'src/hooks/useTokens';
+import { formatTokenAmount, getTokenBySymbol } from 'src/utils';
+import { useWalletBalance } from 'src/hooks/useWalletBalance';
 
 const TokenSelector: FunctionComponent<{
   close: () => void;

--- a/packages/frontend/src/components/TokenSelector/useTokenSelector.tsx
+++ b/packages/frontend/src/components/TokenSelector/useTokenSelector.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { SwapFormType } from '../../providers/SwapFormProvider';
+import { SwapFormType } from 'src/providers/SwapFormProvider';
 
 const useTokenSelector = () => {
   const [tokenSelectorType, setTokenSelectorType] = useState<SwapFormType>('from');

--- a/packages/frontend/src/hooks/useAllowance.tsx
+++ b/packages/frontend/src/hooks/useAllowance.tsx
@@ -1,11 +1,11 @@
 import { ethers } from 'ethers';
 import { erc20ABI, useAccount, useContractRead } from 'wagmi';
+import { getTokenBySymbol } from 'src/utils';
+import { SwapFormKey } from 'src/providers/SwapFormProvider';
+import { ETH_CONTRACT_ADDRESS, MIN_ALLOWANCE } from 'src/constants';
 import { useWatch } from 'react-hook-form';
 import { useQuote } from './useQuote';
 import { useTokens } from './useTokens';
-import { getTokenBySymbol } from '../utils';
-import { SwapFormKey } from '../providers/SwapFormProvider';
-import { ETH_CONTRACT_ADDRESS, MIN_ALLOWANCE } from '../constants';
 
 const useAllowance = () => {
   const { quote, isFetching: isFetchingQuote } = useQuote();

--- a/packages/frontend/src/hooks/useAnalytics.tsx
+++ b/packages/frontend/src/hooks/useAnalytics.tsx
@@ -1,6 +1,6 @@
 import { createContext, FunctionComponent, ReactNode, useContext } from 'react';
 import isChromatic from 'chromatic';
-import { isStorybookDev, isTest } from '../utils';
+import { isStorybookDev, isTest } from 'src/utils';
 
 const analyticsMethods = {
   logEvent: (goalId: string) => {

--- a/packages/frontend/src/hooks/useApprove.tsx
+++ b/packages/frontend/src/hooks/useApprove.tsx
@@ -2,11 +2,11 @@ import { useQuery } from '@tanstack/react-query';
 import { BigNumber, ContractTransaction } from 'ethers';
 import { erc20ABI, useSigner, useContract } from 'wagmi';
 import { useWatch } from 'react-hook-form';
+import { MAX_ALLOWANCE } from 'src/constants';
+import { SwapFormKey } from 'src/providers/SwapFormProvider';
+import { getTokenBySymbol } from 'src/utils';
 import { useQuote } from './useQuote';
 import { useTokens } from './useTokens';
-import { MAX_ALLOWANCE } from '../constants';
-import { SwapFormKey } from '../providers/SwapFormProvider';
-import { getTokenBySymbol } from '../utils';
 
 const useApprove = () => {
   const { data: signer } = useSigner();

--- a/packages/frontend/src/hooks/useConnectWallet.tsx
+++ b/packages/frontend/src/hooks/useConnectWallet.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useConnect } from 'wagmi';
-import { connectors, type SupportedWallet } from '../connectors';
+import { connectors, type SupportedWallet } from 'src/connectors';
 import useAnalytics from './useAnalytics';
 
 // TODO(bill): export types from shared-ui, import here

--- a/packages/frontend/src/hooks/useCullQueries.tsx
+++ b/packages/frontend/src/hooks/useCullQueries.tsx
@@ -1,8 +1,8 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { useWatch } from 'react-hook-form';
-import { SwapFormKey } from '../providers/SwapFormProvider';
-import { getQueryKey, getTokenBySymbol } from '../utils';
+import { SwapFormKey } from 'src/providers/SwapFormProvider';
+import { getQueryKey, getTokenBySymbol } from 'src/utils';
 import { useTokens } from './useTokens';
 
 const useCullQueries = (primaryKey: string) => {

--- a/packages/frontend/src/hooks/useQuote.tsx
+++ b/packages/frontend/src/hooks/useQuote.tsx
@@ -1,13 +1,13 @@
 import { useEffect } from 'react';
+import type { Quote } from '@sifi/sdk';
 import { useQuery } from '@tanstack/react-query';
 import { useFormContext, useWatch } from 'react-hook-form';
 import { ethers } from 'ethers';
-import { useSifi } from '../providers/SDKProvider';
-import { SwapFormKey } from '../providers/SwapFormProvider';
+import { useSifi } from 'src/providers/SDKProvider';
+import { SwapFormKey } from 'src/providers/SwapFormProvider';
+import { formatTokenAmount, getQueryKey, getTokenBySymbol } from 'src/utils';
+import { ETH_CONTRACT_ADDRESS } from 'src/constants';
 import { useTokens } from './useTokens';
-import { formatTokenAmount, getQueryKey, getTokenBySymbol, parseErrorMessage } from '../utils';
-import { ETH_CONTRACT_ADDRESS } from '../constants';
-import type { Quote } from '@sifi/sdk';
 
 const useQuote = () => {
   const sifi = useSifi();

--- a/packages/frontend/src/hooks/useTokenBalance.tsx
+++ b/packages/frontend/src/hooks/useTokenBalance.tsx
@@ -1,6 +1,6 @@
 import { useAccount, useBalance } from 'wagmi';
 import type { Token } from '@sifi/sdk';
-import { ETH_CONTRACT_ADDRESS } from '../constants';
+import { ETH_CONTRACT_ADDRESS } from 'src/constants';
 
 const useTokenBalance = (token: Token | null) => {
   const { address } = useAccount();

--- a/packages/frontend/src/hooks/useTokens.tsx
+++ b/packages/frontend/src/hooks/useTokens.tsx
@@ -1,5 +1,5 @@
 import { useContext } from 'react';
-import { TokensContext } from '../providers/TokensProvider';
+import { TokensContext } from 'src/providers/TokensProvider';
 
 const useTokens = () => useContext(TokensContext);
 

--- a/packages/frontend/src/hooks/useWalletBalance.tsx
+++ b/packages/frontend/src/hooks/useWalletBalance.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
 import { useAccount } from 'wagmi';
-import { baseUrl } from '../utils';
+import { baseUrl } from 'src/utils';
 
 type WalletBalanceToken = {
   balance: string;

--- a/packages/frontend/src/providers/SDKProvider.tsx
+++ b/packages/frontend/src/providers/SDKProvider.tsx
@@ -1,6 +1,5 @@
 import { Sifi } from '@sifi/sdk';
 import { createContext, useContext, useMemo } from 'react';
-import { baseUrl } from '../utils';
 
 let sifi: Sifi;
 

--- a/packages/frontend/src/providers/TokensProvider.tsx
+++ b/packages/frontend/src/providers/TokensProvider.tsx
@@ -7,8 +7,8 @@ import {
   useState,
   useMemo,
 } from 'react';
-import { getOrderedTokenList } from '../utils/tokens';
-import { enableUnlistedTokenTrading } from '../utils/featureFlags';
+import { getOrderedTokenList } from 'src/utils/tokens';
+import { enableUnlistedTokenTrading } from 'src/utils/featureFlags';
 import { useSifi } from './SDKProvider';
 import type { Token } from '@sifi/sdk';
 

--- a/packages/frontend/src/providers/WagmiProvider.tsx
+++ b/packages/frontend/src/providers/WagmiProvider.tsx
@@ -2,7 +2,7 @@ import type { FC, PropsWithChildren } from 'react';
 import { WagmiConfig, createClient, configureChains } from 'wagmi';
 import { mainnet, polygon } from 'wagmi/chains';
 import { publicProvider } from 'wagmi/providers/public';
-import { connectors } from '../connectors';
+import { connectors } from 'src/connectors';
 
 const { provider, webSocketProvider } = configureChains([mainnet, polygon], [publicProvider()]);
 

--- a/packages/frontend/src/utils/tokens.ts
+++ b/packages/frontend/src/utils/tokens.ts
@@ -1,5 +1,5 @@
 import type { Token } from '@sifi/sdk';
-import { POPULAR_TOKEN_SYMBOLS } from '../constants';
+import { POPULAR_TOKEN_SYMBOLS } from 'src/constants';
 
 export const getOrderedTokenList = (tokenList: Token[]) => {
   const popularTokenList = tokenList.filter(token => POPULAR_TOKEN_SYMBOLS.includes(token.symbol));

--- a/packages/frontend/tsconfig.json
+++ b/packages/frontend/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "target": "es6",
     "lib": ["dom", "esnext"],
     "allowJs": true,
@@ -17,6 +18,6 @@
     "composite": true,
     "outDir": "dist"
   },
-  "include": ["src/**/*", ".storybook/decorators/*"],
+  "include": ["src/**/*", ".storybook/decorators/*", "src"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -5,6 +5,11 @@ import svgr from 'vite-plugin-svgr';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react(), svgr()],
+  resolve: {
+    alias: {
+      src: '/src',
+    },
+  },
   optimizeDeps: {
     exclude: ['@sifi/shared-ui'],
     esbuildOptions: {


### PR DESCRIPTION
Sets up Tsconfig and Vite for absolute imports in the Frontend. This gives us much more readable, and scalable code. Updated the imports to match the new standard.

Closes #151 