### PR TITLE
feat(frontend): reduce swap buttons height

### DIFF
--- a/packages/frontend/src/components/Button/Button.stories.tsx
+++ b/packages/frontend/src/components/Button/Button.stories.tsx
@@ -1,16 +1,19 @@
-import { StoryFn, Meta } from "@storybook/react";
-import { Button } from "./Button";
+import { StoryFn, Meta } from '@storybook/react';
+import { Button } from './Button';
 
 export default {
-  title: "Components/Button",
+  title: 'Components/Button',
   component: Button,
 } as Meta<typeof Button>;
 
-const Template: StoryFn<typeof Button> = (args) => (
-  <Button {...args}>Shift</Button>
-);
+const Template: StoryFn<typeof Button> = args => <Button {...args}>Shift</Button>;
 
 export const Default = Template.bind({});
+
+export const Large = Template.bind({});
+Large.args = {
+  size: 'large',
+};
 
 export const Disabled = Template.bind({});
 Disabled.args = {

--- a/packages/frontend/src/components/Button/Button.tsx
+++ b/packages/frontend/src/components/Button/Button.tsx
@@ -3,16 +3,29 @@ import { Spinner } from '../Spinner/Spinner';
 
 type ButtonProps = {
   isLoading?: boolean;
+  size?: 'large' | 'normal';
 } & ButtonHTMLAttributes<HTMLButtonElement>;
 
-const Button: FunctionComponent<ButtonProps> = ({ children, isLoading, ...rest }) => (
-  <button
-    className="bg-primary-purple text-flashbang-white focus:ring-pixel-blue flex h-24 w-full max-w-md place-items-center justify-center rounded-md border border-none py-2 px-4 text-lg uppercase shadow-sm hover:bg-opacity-90 focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:cursor-not-allowed disabled:bg-opacity-60 disabled:text-opacity-60 disabled:hover:bg-opacity-60"
-    disabled={isLoading}
-    {...rest}
-  >
-    {isLoading ? <Spinner /> : children}
-  </button>
-);
+const Button: FunctionComponent<ButtonProps> = ({
+  children,
+  isLoading,
+  size = 'normal',
+  ...rest
+}) => {
+  const styles = {
+    large: 'h-24',
+    normal: 'h-20',
+  };
+
+  return (
+    <button
+      className={`bg-primary-purple text-flashbang-white focus:ring-pixel-blue flex ${styles[size]} w-full max-w-md place-items-center justify-center rounded-md border border-none py-2 px-4 text-lg uppercase shadow-sm hover:bg-opacity-90 focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:cursor-not-allowed disabled:bg-opacity-60 disabled:text-opacity-60 disabled:hover:bg-opacity-60`}
+      disabled={isLoading}
+      {...rest}
+    >
+      {isLoading ? <Spinner /> : children}
+    </button>
+  );
+};
 
 export { Button };


### PR DESCRIPTION
### Changes Made

- Add `size` prop to Button
- Make `normal` default, so all the Swap Buttons are less tall

### Screenshots/videos

<img width="1512" alt="Screenshot 2023-08-30 at 21 35 54" src="https://github.com/sideshiftfi/sifi/assets/128688932/7ff79d63-2de2-482a-9c12-9892b94c72c6">

### Checklist

Please tick the boxes that apply and provide additional details where necessary. Add or edit items as needed.

- [x] Changes are limited to a single goal.
- [x] Responsive design has been tested and looks good on all devices and screen sizes.
- [x] Changes have been tested on all major browsers (Chrome, Firefox, Safari).
- [x] The changes in Chromatic UI Tests all look good.
- [x] No accessibility issues have been introduced in Storybook's Accessibility tab.
- [x] The code has been optimized for performance.

### Related

Closes #172 
