### PR TITLE
fix(frontend): layout jump when gas estimate changes

### DIFF
--- a/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
+++ b/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
@@ -6,12 +6,13 @@ import { useTokens } from 'src/hooks/useTokens';
 import { useTokenBalance } from 'src/hooks/useTokenBalance';
 import { useMutation } from '@tanstack/react-query';
 import { useSifi } from 'src/providers/SDKProvider';
-import { formatTokenAmount, getEvmTxUrl, getTokenBySymbol, parseErrorMessage } from 'src/utils';
+import { getEvmTxUrl, getTokenBySymbol, parseErrorMessage } from 'src/utils';
 import { SwapFormKey, SwapFormKeyHelper } from 'src/providers/SwapFormProvider';
 import { useCullQueries } from 'src/hooks/useCullQueries';
 import { useQuote } from 'src/hooks/useQuote';
 import { CreateSwapButtons } from '../CreateSwapButtons/CreateSwapButtons';
 import { TokenSelector, useTokenSelector } from '../TokenSelector';
+import { SwapInformation } from '../SwapInformation';
 
 const CreateSwap = () => {
   useCullQueries('quote');
@@ -25,7 +26,6 @@ const CreateSwap = () => {
   });
   const fromToken = getTokenBySymbol(fromTokenSymbol, tokens);
   const toToken = getTokenBySymbol(toTokenSymbol, tokens);
-  const { isConnected } = useAccount();
   const [isLoading, setIsLoading] = useState(false);
   const { quote, isFetching: isFetchingQuote } = useQuote();
   const ShiftInputLabel = { from: 'You pay', to: 'You receive' } as const;
@@ -154,24 +154,7 @@ const CreateSwap = () => {
           </div>
         </form>
       </div>
-      {/* Temorary info section */}
-      {isConnected && quote && (
-        <dl className="grid grid-cols-1 gap-x-4 gap-y-8 sm:grid-cols-2">
-          {/* TODO: Add this back in */}
-          {/* <div className="sm:col-span-1">
-            <dt className="text-smoke text-sm font-medium">USD Value</dt>
-            <dd className="font-display text-flashbang-white mt-1 text-sm">
-              {route.toAmountUSD} USD
-            </dd>
-          </div> */}
-          <div className="sm:col-span-1">
-            <dt className="text-smoke text-sm font-medium">Estimated Gas Cost</dt>
-            <dd className="font-display text-flashbang-white mt-1 text-sm">
-              {formatTokenAmount(quote.estimatedGas.toString(), 4)} USD
-            </dd>
-          </div>
-        </dl>
-      )}
+      <SwapInformation />
     </div>
   );
 };

--- a/packages/frontend/src/components/SwapInformation/SwapInformation.tsx
+++ b/packages/frontend/src/components/SwapInformation/SwapInformation.tsx
@@ -1,0 +1,48 @@
+import { Skeleton } from '@sifi/shared-ui';
+import { FunctionComponent } from 'react';
+import { useQuote } from 'src/hooks/useQuote';
+import { formatTokenAmount } from 'src/utils';
+
+const SwapInformation: FunctionComponent = () => {
+  const { quote, isLoading } = useQuote();
+
+  if (isLoading || !quote) {
+    return (
+      <dl className="grid grid-cols-1 gap-x-4 gap-y-8 sm:grid-cols-2">
+        {/* TODO: Add this back in */}
+        {/* <div className="sm:col-span-1">
+            <dt className="text-smoke text-sm font-medium">USD Value</dt>
+            <dd className="font-display text-flashbang-white mt-1 text-sm">
+              {route.toAmountUSD} USD
+            </dd>
+          </div> */}
+        <div className="sm:col-span-1">
+          <dt className="text-smoke text-sm font-medium">Estimated Gas Cost</dt>
+          <dd className="font-display text-flashbang-white mt-1 text-sm">
+            <Skeleton className="w-24 h-5" />
+          </dd>
+        </div>
+      </dl>
+    );
+  }
+
+  return (
+    <dl className="grid grid-cols-1 gap-x-4 gap-y-8 sm:grid-cols-2">
+      {/* TODO: Add this back in */}
+      {/* <div className="sm:col-span-1">
+            <dt className="text-smoke text-sm font-medium">USD Value</dt>
+            <dd className="font-display text-flashbang-white mt-1 text-sm">
+              {route.toAmountUSD} USD
+            </dd>
+          </div> */}
+      <div className="sm:col-span-1">
+        <dt className="text-smoke text-sm font-medium">Estimated Gas Cost</dt>
+        <dd className="font-display text-flashbang-white mt-1 text-sm">
+          {formatTokenAmount(quote.estimatedGas.toString(), 4)} USD
+        </dd>
+      </div>
+    </dl>
+  );
+};
+
+export { SwapInformation };

--- a/packages/frontend/src/components/SwapInformation/index.ts
+++ b/packages/frontend/src/components/SwapInformation/index.ts
@@ -1,0 +1,1 @@
+export * from './SwapInformation';


### PR DESCRIPTION
### Changes Made

- Move Gas Estimate (and the soon to be re-added USD value) to a SwapInformation Component
- Don't hide gas estimate when not connected, since it still works
- Add a loading state to avoid layout jumps

### Screenshots/videos

https://github.com/sideshiftfi/sifi/assets/128688932/c73abe3e-e194-419c-be7a-4966c94ac320

### Checklist

Please tick the boxes that apply and provide additional details where necessary. Add or edit items as needed.

- [x] Changes are limited to a single goal.
- [x] Responsive design has been tested and looks good on all devices and screen sizes.
- [x] Changes have been tested on all major browsers (Chrome, Firefox, Safari).
- [x] The changes in Chromatic UI Tests all look good.
- [x] No accessibility issues have been introduced in Storybook's Accessibility tab.
- [x] The code has been optimized for performance.

### Related

Closes #173
