### PR TITLE
feat(frontend): handle same token pairs in create swap

### DIFF
--- a/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
+++ b/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
@@ -31,6 +31,7 @@ const CreateSwap = () => {
   const ShiftInputLabel = { from: 'You pay', to: 'You receive' } as const;
   const { data: fromBalance, refetch: refetchFromBalance } = useTokenBalance(fromToken);
   const { data: toBalance, refetch: refetchToBalance } = useTokenBalance(toToken);
+  const isSameTokenPair = fromToken && toToken && fromToken.address === toToken.address;
 
   const isToSwapInputLoading = isFetchingQuote;
 
@@ -116,6 +117,13 @@ const CreateSwap = () => {
     }
   }, [tokens]);
 
+  useEffect(() => {
+    if (isSameTokenPair) {
+      setValue(SwapFormKey.FromAmount, '');
+      setValue(SwapFormKey.ToAmount, '');
+    }
+  }, [isSameTokenPair]);
+
   return (
     <div className="m:w-full py-2 sm:max-w-md">
       <div className="bg-white pb-8 shadow sm:rounded-lg">
@@ -130,6 +138,7 @@ const CreateSwap = () => {
                   id={fromId}
                   openSelector={() => openTokenSelector('from')}
                   formMethods={methods}
+                  disabled={Boolean(isSameTokenPair)}
                 />
               </div>
               <ShiftInput

--- a/packages/frontend/src/components/CreateSwapButtons/CreateSwapButtons.tsx
+++ b/packages/frontend/src/components/CreateSwapButtons/CreateSwapButtons.tsx
@@ -24,10 +24,11 @@ const CreateSwapButtons = ({ isLoading }: { isLoading: boolean }) => {
   const { tokens } = useTokens();
   const { isFetching: isApproving } = useApprove();
   const { allowance, isAllowanceAboveFromAmount, isFetching: isFetchingAllowance } = useAllowance();
-  const [fromTokenSymbol, fromAmount] = useWatch({
-    name: [SwapFormKey.FromToken, SwapFormKey.FromAmount],
+  const [fromTokenSymbol, toTokenSymbol, fromAmount] = useWatch({
+    name: [SwapFormKey.FromToken, SwapFormKey.ToToken, SwapFormKey.FromAmount],
   });
   const fromToken = getTokenBySymbol(fromTokenSymbol, tokens);
+  const toToken = getTokenBySymbol(toTokenSymbol, tokens);
   const isFromEthereum = fromToken?.address === ETH_CONTRACT_ADDRESS;
   const userIsConnectedToWrongNetwork = Boolean(
     chain?.id && fromToken?.chainId && chain.id !== fromToken.chainId
@@ -51,7 +52,12 @@ const CreateSwapButtons = ({ isLoading }: { isLoading: boolean }) => {
     !isConnected || showApproveButton || !fromAmount || !hasSufficientBalance;
 
   const getShiftButtonLabel = () => {
+    if (fromToken?.address === toToken?.address) {
+      return 'Cannot shift same tokens';
+    }
+
     if (!fromAmount) return 'Enter an amount';
+
     const hasFetchedSwapQuote = !!quote || isFromEthereum;
     if (fromBalance && hasFetchedSwapQuote && !hasSufficientBalance) {
       // TODO: Does not work properly once switching to a Token

--- a/packages/frontend/src/hooks/useQuote.tsx
+++ b/packages/frontend/src/hooks/useQuote.tsx
@@ -19,6 +19,7 @@ const useQuote = () => {
   const fromToken = getTokenBySymbol(fromTokenSymbol, tokens);
   const toToken = getTokenBySymbol(toTokenSymbol, tokens);
   const isFromEthereum = fromToken?.address === ETH_CONTRACT_ADDRESS;
+  const isSameTokenPair = fromToken?.address === toToken?.address;
 
   const quoteRequest = {
     fromToken: fromToken?.address || ETH_CONTRACT_ADDRESS,
@@ -35,7 +36,7 @@ const useQuote = () => {
     setValue(SwapFormKey.ToAmount, formatTokenAmount(quote.toAmount.toString(), toToken?.decimals));
   };
 
-  const enabled = !!fromToken && !!toToken && !!fromAmount;
+  const enabled = Boolean(fromToken) && Boolean(toToken) && Boolean(fromAmount) && !isSameTokenPair;
   const queryKey = getQueryKey('quote', fromAmount, toToken?.address, fromToken?.address);
 
   // TODO: Quote gets fetched 4 times


### PR DESCRIPTION
### Changes Made

- Handle Same Token Pairs in CreateSwap, we don't request a quote, change the button label and clear + disable the shift inputs

### Screenshots/videos

<img width="1512" alt="Screenshot 2023-08-31 at 14 36 54" src="https://github.com/sideshiftfi/sifi/assets/128688932/336357a4-da24-43b3-92f6-5e03208d5341">

### Checklist

Please tick the boxes that apply and provide additional details where necessary. Add or edit items as needed.

- [x] Changes are limited to a single goal.
- [x] Responsive design has been tested and looks good on all devices and screen sizes.
- [x] Changes have been tested on all major browsers (Chrome, Firefox, Safari).
- [x] The changes in Chromatic UI Tests all look good.
- [x] No accessibility issues have been introduced in Storybook's Accessibility tab.
- [x] The code has been optimized for performance.

### Related

Closes #146 
