### PR TITLE
feat(frontend): handle zero amounts for create swap

### DIFF
--- a/packages/frontend/src/components/CreateSwapButtons/CreateSwapButtons.tsx
+++ b/packages/frontend/src/components/CreateSwapButtons/CreateSwapButtons.tsx
@@ -7,7 +7,7 @@ import { useApprove } from 'src/hooks/useApprove';
 import { useTokens } from 'src/hooks/useTokens';
 import { useQuote } from 'src/hooks/useQuote';
 import { SwapFormKey } from 'src/providers/SwapFormProvider';
-import { getTokenBySymbol } from 'src/utils';
+import { getTokenBySymbol, isValidTokenAmount } from 'src/utils';
 import { ETH_CONTRACT_ADDRESS } from 'src/constants';
 import { useTokenBalance } from 'src/hooks/useTokenBalance';
 import { ApproveButton } from './ApproveButton';
@@ -49,7 +49,11 @@ const CreateSwapButtons = ({ isLoading }: { isLoading: boolean }) => {
     ) || isApproving;
 
   const isShiftButtonDisabled =
-    !isConnected || showApproveButton || !fromAmount || !hasSufficientBalance;
+    !isConnected ||
+    showApproveButton ||
+    !fromAmount ||
+    !hasSufficientBalance ||
+    !isValidTokenAmount(fromAmount);
 
   const getShiftButtonLabel = () => {
     if (fromToken?.address === toToken?.address) {
@@ -57,6 +61,8 @@ const CreateSwapButtons = ({ isLoading }: { isLoading: boolean }) => {
     }
 
     if (!fromAmount) return 'Enter an amount';
+
+    if (!isValidTokenAmount(fromAmount)) return 'Enter a valid amount';
 
     const hasFetchedSwapQuote = !!quote || isFromEthereum;
     if (fromBalance && hasFetchedSwapQuote && !hasSufficientBalance) {

--- a/packages/frontend/src/hooks/useQuote.tsx
+++ b/packages/frontend/src/hooks/useQuote.tsx
@@ -5,7 +5,7 @@ import { useFormContext, useWatch } from 'react-hook-form';
 import { ethers } from 'ethers';
 import { useSifi } from 'src/providers/SDKProvider';
 import { SwapFormKey } from 'src/providers/SwapFormProvider';
-import { formatTokenAmount, getQueryKey, getTokenBySymbol } from 'src/utils';
+import { formatTokenAmount, getQueryKey, getTokenBySymbol, isValidTokenAmount } from 'src/utils';
 import { ETH_CONTRACT_ADDRESS } from 'src/constants';
 import { useTokens } from './useTokens';
 
@@ -36,7 +36,12 @@ const useQuote = () => {
     setValue(SwapFormKey.ToAmount, formatTokenAmount(quote.toAmount.toString(), toToken?.decimals));
   };
 
-  const enabled = Boolean(fromToken) && Boolean(toToken) && Boolean(fromAmount) && !isSameTokenPair;
+  const enabled =
+    Boolean(fromToken) &&
+    Boolean(toToken) &&
+    Boolean(fromAmount) &&
+    !isSameTokenPair &&
+    isValidTokenAmount(fromAmount);
   const queryKey = getQueryKey('quote', fromAmount, toToken?.address, fromToken?.address);
 
   // TODO: Quote gets fetched 4 times

--- a/packages/frontend/src/utils/index.ts
+++ b/packages/frontend/src/utils/index.ts
@@ -5,3 +5,4 @@ export * from './queries';
 export * from './api';
 export * from './parseErrorMessage';
 export * from './evm';
+export * from './isValidTokenAmount';

--- a/packages/frontend/src/utils/isValidTokenAmount.ts
+++ b/packages/frontend/src/utils/isValidTokenAmount.ts
@@ -1,0 +1,5 @@
+const isValidTokenAmount = (value?: string): boolean => {
+  return Boolean(value) && value !== '0' && Boolean(Number(value));
+};
+
+export { isValidTokenAmount };


### PR DESCRIPTION
This PR adds improved handling for when the user enters amounts such as `'0'` or `'0.0'` or `'000'` etc.

### Changes Made

- Add `isValidTokenAmount` util function
- Disable quote fetching when this function returns `false`
- Update Button Label when this function returns `false`

### Screenshots/videos

https://github.com/sideshiftfi/sifi/assets/128688932/e42541b1-a842-422f-8564-74cabd3dea89

### Testing

- [x] No quotes are fetched when `isValidTokenAmount` returns false
- [x] Quote still fetches when it should
- [x] Button label continues to show correct states

### Checklist

Please tick the boxes that apply and provide additional details where necessary. Add or edit items as needed.

- [x] Changes are limited to a single goal.
- [x] Responsive design has been tested and looks good on all devices and screen sizes.
- [x] Changes have been tested on all major browsers (Chrome, Firefox, Safari).
- [x] The changes in Chromatic UI Tests all look good.
- [x] No accessibility issues have been introduced in Storybook's Accessibility tab.
- [x] The code has been optimized for performance.

### Related

Closes #178 
