### PR TITLE
feat(frontend): use viem multicall to fetch token balances

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -38,7 +38,8 @@
     "tailwindcss": "^3.2.0",
     "scrypt-js": "3.0.1",
     "viem": "^1.9.0",
-    "wagmi": "^1.3.10"
+    "wagmi": "^1.3.10",
+    "@wagmi/core": "^1.3.10"
   },
   "devDependencies": {
     "@babel/core": "^7.20.2",

--- a/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
+++ b/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
@@ -14,6 +14,8 @@ import { useQuote } from 'src/hooks/useQuote';
 import { CreateSwapButtons } from '../CreateSwapButtons/CreateSwapButtons';
 import { TokenSelector, useTokenSelector } from '../TokenSelector';
 import { SwapInformation } from '../SwapInformation';
+import { MulticallToken } from 'src/types';
+import { useMultiCallTokenBalance } from 'src/hooks/useMulticallTokenBalance';
 
 const CreateSwap = () => {
   useCullQueries('quote');
@@ -23,6 +25,7 @@ const CreateSwap = () => {
   const { data: walletClient } = useWalletClient();
   const { handleSubmit } = useForm();
   const { tokens } = useTokens();
+  const { balanceMap, refetch: refetchTokenBalances } = useMultiCallTokenBalance(tokens as MulticallToken[]);
   const [fromTokenSymbol, toTokenSymbol] = useWatch({
     name: [SwapFormKey.FromToken, SwapFormKey.ToToken, SwapFormKey.FromAmount],
   });
@@ -86,6 +89,7 @@ const CreateSwap = () => {
 
         refetchFromBalance();
         refetchToBalance();
+        refetchTokenBalances();
         setValue(SwapFormKey.FromAmount, '');
       },
     }
@@ -154,6 +158,7 @@ const CreateSwap = () => {
                 formMethods={methods}
               />
               <TokenSelector
+                balanceMap={balanceMap}
                 close={closeTokenSelector}
                 isOpen={isTokenSelectorOpen}
                 type={tokenSelectorType}

--- a/packages/frontend/src/components/TokenSelector/TokenSelector.tsx
+++ b/packages/frontend/src/components/TokenSelector/TokenSelector.tsx
@@ -6,6 +6,8 @@ import { SwapFormKeyHelper, SwapFormType } from 'src/providers/SwapFormProvider'
 import { useTokens } from 'src/hooks/useTokens';
 import { formatTokenAmount, getTokenBySymbol } from 'src/utils';
 import { useWalletBalance } from 'src/hooks/useWalletBalance';
+import { useMultiCallTokenBalance } from 'src/hooks/useMulticallTokenBalance';
+import type { MulticallToken } from 'src/types';
 
 const TokenSelector: FunctionComponent<{
   close: () => void;
@@ -18,6 +20,7 @@ const TokenSelector: FunctionComponent<{
   const { setValue, watch } = useFormContext();
   const selectedToken = getTokenBySymbol(watch(selectId), tokens);
   const { data: walletBalanceData } = useWalletBalance();
+  const balanceMap = useMultiCallTokenBalance(tokens as MulticallToken[]);
 
   const handleSelectToken = (newTokenAddress: `0x${string}`) => {
     const newToken = tokens?.find(token => token.address === newTokenAddress);
@@ -29,21 +32,16 @@ const TokenSelector: FunctionComponent<{
   const formattedTokens = useMemo(
     () =>
       tokens?.map(token => {
-        const walletToken = walletBalanceData?.find(
-          walletToken => walletToken.tokenAddress.toLowerCase() === token.address.toLowerCase()
-        );
-
+        const balance = balanceMap?.get(token.address.toLowerCase() as `0x${string}`)?.toString() || undefined;
         return {
-          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           id: token.address as `0x${string}`,
           logoURI: token.logoURI,
           name: token.name,
           networkDisplayName: null,
           symbol: token.symbol,
           networkLogoURI: null,
-          balance: Boolean(address) ? formatTokenAmount(walletToken?.balance ?? '0') : undefined,
-        };
-      }),
+          balance,
+        }}),
     [tokens, walletBalanceData, address]
   );
 

--- a/packages/frontend/src/components/TokenSelector/TokenSelector.tsx
+++ b/packages/frontend/src/components/TokenSelector/TokenSelector.tsx
@@ -4,23 +4,20 @@ import { useFormContext } from 'react-hook-form';
 import { CoinSelector } from '@sifi/shared-ui';
 import { SwapFormKeyHelper, SwapFormType } from 'src/providers/SwapFormProvider';
 import { useTokens } from 'src/hooks/useTokens';
-import { formatTokenAmount, getTokenBySymbol } from 'src/utils';
-import { useWalletBalance } from 'src/hooks/useWalletBalance';
-import { useMultiCallTokenBalance } from 'src/hooks/useMulticallTokenBalance';
-import type { MulticallToken } from 'src/types';
+import { getTokenBySymbol } from 'src/utils';
+import type { BalanceMap } from 'src/types';
 
 const TokenSelector: FunctionComponent<{
   close: () => void;
   isOpen: boolean;
   type: SwapFormType;
-}> = ({ isOpen, close, type }) => {
+  balanceMap: BalanceMap | null;
+}> = ({ isOpen, close, type, balanceMap }) => {
   const selectId = SwapFormKeyHelper.getTokenKey(type);
   const { address } = useAccount();
   const { tokens, fetchTokenByAddress } = useTokens();
   const { setValue, watch } = useFormContext();
   const selectedToken = getTokenBySymbol(watch(selectId), tokens);
-  const { data: walletBalanceData } = useWalletBalance();
-  const balanceMap = useMultiCallTokenBalance(tokens as MulticallToken[]);
 
   const handleSelectToken = (newTokenAddress: `0x${string}`) => {
     const newToken = tokens?.find(token => token.address === newTokenAddress);
@@ -30,8 +27,8 @@ const TokenSelector: FunctionComponent<{
   };
 
   const formattedTokens = useMemo(
-    () =>
-      tokens?.map(token => {
+    () =>{
+      return tokens?.map(token => {
         const balance = balanceMap?.get(token.address.toLowerCase() as `0x${string}`)?.toString() || undefined;
         return {
           id: token.address as `0x${string}`,
@@ -41,7 +38,7 @@ const TokenSelector: FunctionComponent<{
           symbol: token.symbol,
           networkLogoURI: null,
           balance,
-        }}),
+        }})},
     [tokens, balanceMap, address]
   );
 

--- a/packages/frontend/src/components/TokenSelector/TokenSelector.tsx
+++ b/packages/frontend/src/components/TokenSelector/TokenSelector.tsx
@@ -42,7 +42,7 @@ const TokenSelector: FunctionComponent<{
           networkLogoURI: null,
           balance,
         }}),
-    [tokens, walletBalanceData, address]
+    [tokens, balanceMap, address]
   );
 
   if (!formattedTokens) return null;

--- a/packages/frontend/src/constants.ts
+++ b/packages/frontend/src/constants.ts
@@ -3,4 +3,16 @@ const MIN_ALLOWANCE = '0xffffffffffffffffffffffffffffff';
 const MAX_ALLOWANCE = '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
 const POPULAR_TOKEN_SYMBOLS = ['ETH', 'USDT', 'XAI', 'USDC', 'WBTC', 'BUSD', 'DAI'];
 
-export { ETH_CONTRACT_ADDRESS, MIN_ALLOWANCE, MAX_ALLOWANCE, POPULAR_TOKEN_SYMBOLS };
+// Standard ERC20 ABI for `balanceOf` function
+const ERC20_ABI = [
+  {
+    constant: true,
+    inputs: [{ name: 'owner', type: 'address' }],
+    name: 'balanceOf',
+    outputs: [{ name: '', type: 'uint256' }],
+    type: 'function',
+    stateMutability: 'view',
+  },
+] as const;
+
+export { ETH_CONTRACT_ADDRESS, MIN_ALLOWANCE, MAX_ALLOWANCE, POPULAR_TOKEN_SYMBOLS, ERC20_ABI };

--- a/packages/frontend/src/constants.ts
+++ b/packages/frontend/src/constants.ts
@@ -13,14 +13,6 @@ const ERC20_ABI = [
     type: 'function',
     stateMutability: 'view',
   },
-  {
-    constant: true,
-    inputs: [],
-    name: 'decimals',
-    outputs: [{ name: '', type: 'uint8' }],
-    type: 'function',
-    stateMutability: 'view',
-  },
 ] as const;
 
 export { ETH_CONTRACT_ADDRESS, MIN_ALLOWANCE, MAX_ALLOWANCE, POPULAR_TOKEN_SYMBOLS, ERC20_ABI };

--- a/packages/frontend/src/constants.ts
+++ b/packages/frontend/src/constants.ts
@@ -13,6 +13,14 @@ const ERC20_ABI = [
     type: 'function',
     stateMutability: 'view',
   },
+  {
+    constant: true,
+    inputs: [],
+    name: 'decimals',
+    outputs: [{ name: '', type: 'uint8' }],
+    type: 'function',
+    stateMutability: 'view',
+  },
 ] as const;
 
 export { ETH_CONTRACT_ADDRESS, MIN_ALLOWANCE, MAX_ALLOWANCE, POPULAR_TOKEN_SYMBOLS, ERC20_ABI };

--- a/packages/frontend/src/hooks/useMulticallTokenBalance.tsx
+++ b/packages/frontend/src/hooks/useMulticallTokenBalance.tsx
@@ -1,36 +1,51 @@
-import { Token } from "@sifi/sdk";
 import { useAccount, usePublicClient } from "wagmi"
 import { useEffect, useState } from "react";
 import { ERC20_ABI } from "src/constants";
 import type { BalanceMap, MulticallToken } from 'src/types';
+import { formatUnits } from "viem";
+import { formatTokenAmount } from "src/utils";
 
 const useMultiCallTokenBalance = (tokens: MulticallToken[]): BalanceMap | null => {
   const { address } = useAccount();
   const [addressBalanceMap, setAddressBalanceMap] = useState<BalanceMap | null>(null)
   const publicClient = usePublicClient();
 
-  const tokenContracts = address?.startsWith('0x') ? tokens.map(token => ({
+  const balanceReadContracts = address?.startsWith('0x') ? tokens.map(token => ({
     address: token.address,
     abi: ERC20_ABI,
     functionName: 'balanceOf',
     args: [address],
   })) : [];
 
+  const decimalReadContracts = tokens.map(token => ({
+    address: token.address,
+    abi: ERC20_ABI,
+    functionName: 'decimals',
+  }));
+
   const fetchBalances = async () => {
-    const data = await publicClient.multicall({ contracts: tokenContracts });
+    const balanceData = await publicClient.multicall({ contracts: balanceReadContracts });
+    const decimalData = await publicClient.multicall({ contracts: decimalReadContracts });
+
     const balanceMap: BalanceMap = new Map();
   
-    for(let i=0; i<tokenContracts.length; i++) {
-      const { status, ...args } = data[i];
-      const tokenAddress = tokenContracts[i].address.toLowerCase() as `0x${string}`;
+    for(let i=0; i<balanceReadContracts.length; i++) {
+      const { status: balanceStatus, ...balanceArgs } = balanceData[i];
+      const { status: decimalStatus, ...decimalArgs } = decimalData[i];
 
-      if (status === 'success') {
-        const { result } = args as { result: bigint };
-        balanceMap.set(tokenAddress, result);
+      const tokenAddress = balanceReadContracts[i].address.toLowerCase() as `0x${string}`;
+
+      if (balanceStatus === 'success' && decimalStatus === 'success') {
+        const { result: rawBalance } = balanceArgs as { result: bigint };
+        const { result: decimals } = decimalArgs as { result: number };
+
+        const formattedTokenBalance = formatTokenAmount(formatUnits(rawBalance, decimals));
+  
+        balanceMap.set(tokenAddress, formattedTokenBalance);
         continue;
       }
 
-      balanceMap.set(tokenAddress, BigInt("0"));
+      balanceMap.set(tokenAddress, '0');
     }
 
     setAddressBalanceMap(balanceMap);

--- a/packages/frontend/src/hooks/useMulticallTokenBalance.tsx
+++ b/packages/frontend/src/hooks/useMulticallTokenBalance.tsx
@@ -1,11 +1,15 @@
-import { fetchBalance } from '@wagmi/core'
 import { useAccount, usePublicClient } from "wagmi"
 import { useEffect, useState } from "react";
 import { ERC20_ABI, ETH_CONTRACT_ADDRESS } from "src/constants";
 import type { BalanceMap, MulticallToken } from 'src/types';
 import { formatTokenAmount } from "src/utils";
 
-const useMultiCallTokenBalance = (tokens: MulticallToken[]): BalanceMap | null => {
+type UseMultiCallTokenBalance = {
+  balanceMap: BalanceMap | null;
+  refetch: () => void;
+}
+
+const useMultiCallTokenBalance = (tokens: MulticallToken[]): UseMultiCallTokenBalance => {
   const { address } = useAccount();
   const [addressBalanceMap, setAddressBalanceMap] = useState<BalanceMap | null>(null)
   const publicClient = usePublicClient();
@@ -72,12 +76,11 @@ const useMultiCallTokenBalance = (tokens: MulticallToken[]): BalanceMap | null =
   }
 
   useEffect(() => {
-    if (!address) return;
+    if (!address || !(tokens.length > 0)) return;
     fetchBalances();
-  }, [address]);
+  }, [address, tokens]);
 
-  return addressBalanceMap;
+  return { balanceMap: addressBalanceMap, refetch: fetchBalances };
 };
 
 export { useMultiCallTokenBalance };
-export type { MulticallToken };

--- a/packages/frontend/src/hooks/useMulticallTokenBalance.tsx
+++ b/packages/frontend/src/hooks/useMulticallTokenBalance.tsx
@@ -1,0 +1,48 @@
+import { Token } from "@sifi/sdk";
+import { useAccount, usePublicClient } from "wagmi"
+import { useEffect, useState } from "react";
+import { ERC20_ABI } from "src/constants";
+import type { BalanceMap, MulticallToken } from 'src/types';
+
+const useMultiCallTokenBalance = (tokens: MulticallToken[]): BalanceMap | null => {
+  const { address } = useAccount();
+  const [addressBalanceMap, setAddressBalanceMap] = useState<BalanceMap | null>(null)
+  const publicClient = usePublicClient();
+
+  const tokenContracts = address?.startsWith('0x') ? tokens.map(token => ({
+    address: token.address,
+    abi: ERC20_ABI,
+    functionName: 'balanceOf',
+    args: [address],
+  })) : [];
+
+  const fetchBalances = async () => {
+    const data = await publicClient.multicall({ contracts: tokenContracts });
+    const balanceMap: BalanceMap = new Map();
+  
+    for(let i=0; i<tokenContracts.length; i++) {
+      const { status, ...args } = data[i];
+      const tokenAddress = tokenContracts[i].address.toLowerCase() as `0x${string}`;
+
+      if (status === 'success') {
+        const { result } = args as { result: bigint };
+        balanceMap.set(tokenAddress, result);
+        continue;
+      }
+
+      balanceMap.set(tokenAddress, BigInt("0"));
+    }
+
+    setAddressBalanceMap(balanceMap);
+  }
+
+  useEffect(() => {
+    if (!address) return;
+    fetchBalances();
+  }, [address]);
+
+  return addressBalanceMap;
+};
+
+export { useMultiCallTokenBalance };
+export type { MulticallToken };

--- a/packages/frontend/src/hooks/useMulticallTokenBalance.tsx
+++ b/packages/frontend/src/hooks/useMulticallTokenBalance.tsx
@@ -75,8 +75,16 @@ const useMultiCallTokenBalance = (tokens: MulticallToken[]): UseMultiCallTokenBa
       setAddressBalanceMap(balanceMap);
   }
 
+  const clearBalances = () => {
+    setAddressBalanceMap(null);
+  }
+
   useEffect(() => {
-    if (!address || !(tokens.length > 0)) return;
+    if (!address || !(tokens.length > 0)) {
+      clearBalances();
+      return;
+    };
+
     fetchBalances();
   }, [address, tokens]);
 

--- a/packages/frontend/src/types.ts
+++ b/packages/frontend/src/types.ts
@@ -1,6 +1,6 @@
 import type { Token } from "@sifi/sdk";
 
 type MulticallToken = Omit<Token, 'address'> & { address: `0x${string}` };
-type BalanceMap = Map<`0x${string}`, bigint>;
+type BalanceMap = Map<`0x${string}`, string>;
 
 export type { MulticallToken, BalanceMap };

--- a/packages/frontend/src/types.ts
+++ b/packages/frontend/src/types.ts
@@ -1,0 +1,6 @@
+import type { Token } from "@sifi/sdk";
+
+type MulticallToken = Omit<Token, 'address'> & { address: `0x${string}` };
+type BalanceMap = Map<`0x${string}`, bigint>;
+
+export type { MulticallToken, BalanceMap };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^4.13.0
         version: 4.28.0(react-dom@18.2.0)(react@18.2.0)
+      '@wagmi/core':
+        specifier: ^1.3.10
+        version: 1.3.10(react@18.2.0)(typescript@5.2.2)(viem@1.9.0)
       aes-js:
         specifier: 3.0.0
         version: 3.0.0
@@ -4110,10 +4113,6 @@ packages:
     resolution: {integrity: sha512-mscwGroSJQrCTjtNGBu+18FQbZYA4+q6Tyx6K7CXHl6AwgZKbWfZYdgP2F+fyZcRUdGRsMX8QtvU61VcGGtO1A==}
     dev: false
 
-  /@lit-labs/ssr-dom-shim@1.0.0:
-    resolution: {integrity: sha512-ic93MBXfApIFTrup4a70M/+ddD8xdt2zxxj9sRwHQzhS9ag/syqkD8JPdTXsc1gUy2K8TTirhlCqyTEM/sifNw==}
-    dev: false
-
   /@lit-labs/ssr-dom-shim@1.1.1:
     resolution: {integrity: sha512-kXOeFbfCm4fFf2A3WwVEeQj55tMZa8c8/f9AKHMobQMkzNUfUj+antR3fRPaZJawsa1aZiP/Da3ndpZrwEe4rQ==}
     dev: false
@@ -4121,7 +4120,7 @@ packages:
   /@lit/reactive-element@1.6.1:
     resolution: {integrity: sha512-va15kYZr7KZNNPZdxONGQzpUr+4sxVu7V/VG7a8mRfPPXUyhEYj5RzXCQmGrlP3tAh0L3HHm5AjBMFYRqlM9SA==}
     dependencies:
-      '@lit-labs/ssr-dom-shim': 1.0.0
+      '@lit-labs/ssr-dom-shim': 1.1.1
     dev: false
 
   /@mdx-js/react@2.3.0(react@18.2.0):
@@ -4276,6 +4275,7 @@ packages:
 
   /@noble/hashes@1.2.0:
     resolution: {integrity: sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==}
+    dev: true
 
   /@noble/hashes@1.3.0:
     resolution: {integrity: sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==}
@@ -5600,7 +5600,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.22.6
       '@noble/ed25519': 1.7.3
-      '@noble/hashes': 1.2.0
+      '@noble/hashes': 1.3.1
       '@noble/secp256k1': 1.7.1
       '@solana/buffer-layout': 4.0.1
       agentkeepalive: 4.4.0
@@ -7870,6 +7870,17 @@ packages:
       typescript: 5.2.2
     dev: false
 
+  /@wagmi/chains@1.8.0(typescript@5.2.2):
+    resolution: {integrity: sha512-UXo0GF0Cl0+neKC2KAmVAahv8L/5rACbFRRqkDvHMefzY6Fh7yzJd8F4GaGNNG3w4hj8eUB/E3+dEpaTYDN62w==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      typescript: 5.2.2
+    dev: false
+
   /@wagmi/connectors@2.7.0(@wagmi/chains@1.7.0)(react@18.2.0)(typescript@5.2.2)(viem@1.9.0):
     resolution: {integrity: sha512-1KOL0HTJl5kzSC/YdKwFwiokr6poUQn1V/tcT0TpG3iH2x0lSM7FTkvCjVVY/6lKzTXrLlo9y2aE7AsOPnkvqg==}
     peerDependencies:
@@ -7906,6 +7917,70 @@ packages:
       - zod
     dev: false
 
+  /@wagmi/connectors@3.0.0(@wagmi/chains@1.8.0)(react@18.2.0)(typescript@5.2.2)(viem@1.9.0):
+    resolution: {integrity: sha512-phHrd4dKctynlh7eRefsaWuh2NF9T24tkLmUHctJeZg/tPzvw+sRFy0XlP7kLw/kwKArn2oSvck7iFemvMeLoQ==}
+    peerDependencies:
+      '@wagmi/chains': '>=1.8.0'
+      typescript: '>=5.0.4'
+      viem: '>=0.3.35'
+    peerDependenciesMeta:
+      '@wagmi/chains':
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      '@coinbase/wallet-sdk': 3.7.1
+      '@ledgerhq/connect-kit-loader': 1.1.2
+      '@safe-global/safe-apps-provider': 0.17.1(typescript@5.2.2)
+      '@safe-global/safe-apps-sdk': 8.1.0(typescript@5.2.2)
+      '@wagmi/chains': 1.8.0(typescript@5.2.2)
+      '@walletconnect/ethereum-provider': 2.10.0(@walletconnect/modal@2.6.1)
+      '@walletconnect/legacy-provider': 2.0.0
+      '@walletconnect/modal': 2.6.1(react@18.2.0)
+      '@walletconnect/utils': 2.10.0
+      abitype: 0.8.7(typescript@5.2.2)
+      eventemitter3: 4.0.7
+      typescript: 5.2.2
+      viem: 1.9.0(typescript@5.2.2)
+    transitivePeerDependencies:
+      - '@react-native-async-storage/async-storage'
+      - bufferutil
+      - encoding
+      - lokijs
+      - react
+      - supports-color
+      - utf-8-validate
+      - zod
+    dev: false
+
+  /@wagmi/core@1.3.10(react@18.2.0)(typescript@5.2.2)(viem@1.9.0):
+    resolution: {integrity: sha512-sJ+nTUppsEkJqZ6gwM4PK6yNlD/CsT4ejRXbad2RoM9fuNDHzZIUA9g+7b0BpgTpyXDYbjk0vBUXHUFMSlmyIA==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+      viem: '>=0.3.35'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@wagmi/chains': 1.8.0(typescript@5.2.2)
+      '@wagmi/connectors': 3.0.0(@wagmi/chains@1.8.0)(react@18.2.0)(typescript@5.2.2)(viem@1.9.0)
+      abitype: 0.8.7(typescript@5.2.2)
+      eventemitter3: 4.0.7
+      typescript: 5.2.2
+      viem: 1.9.0(typescript@5.2.2)
+      zustand: 4.3.3(react@18.2.0)
+    transitivePeerDependencies:
+      - '@react-native-async-storage/async-storage'
+      - bufferutil
+      - encoding
+      - immer
+      - lokijs
+      - react
+      - supports-color
+      - utf-8-validate
+      - zod
+    dev: false
+
   /@wagmi/core@1.3.9(react@18.2.0)(typescript@5.2.2)(viem@1.9.0):
     resolution: {integrity: sha512-SrnABCrsDvhiMCLLLyzyHnZbEumsFT/XWlJJQZeyEDcixL95R7XQwOaaoRI4MpNilCtMtu3jzN57tA5Z2iA+kw==}
     peerDependencies:
@@ -7932,6 +8007,32 @@ packages:
       - supports-color
       - utf-8-validate
       - zod
+    dev: false
+
+  /@walletconnect/core@2.10.0:
+    resolution: {integrity: sha512-Z8pdorfIMueuiBXLdnf7yloiO9JIiobuxN3j0OTal+MYc4q5/2O7d+jdD1DAXbLi1taJx3x60UXT/FPVkjIqIQ==}
+    dependencies:
+      '@walletconnect/heartbeat': 1.2.1
+      '@walletconnect/jsonrpc-provider': 1.0.13
+      '@walletconnect/jsonrpc-types': 1.0.3
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/jsonrpc-ws-connection': 1.0.13
+      '@walletconnect/keyvaluestorage': 1.0.2
+      '@walletconnect/logger': 2.0.1
+      '@walletconnect/relay-api': 1.0.9
+      '@walletconnect/relay-auth': 1.0.4
+      '@walletconnect/safe-json': 1.0.2
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.10.0
+      '@walletconnect/utils': 2.10.0
+      events: 3.3.0
+      lodash.isequal: 4.5.0
+      uint8arrays: 3.1.1
+    transitivePeerDependencies:
+      - '@react-native-async-storage/async-storage'
+      - bufferutil
+      - lokijs
+      - utf-8-validate
     dev: false
 
   /@walletconnect/core@2.9.2:
@@ -7985,6 +8086,32 @@ packages:
       tslib: 1.14.1
     dev: false
 
+  /@walletconnect/ethereum-provider@2.10.0(@walletconnect/modal@2.6.1):
+    resolution: {integrity: sha512-NyTm7RcrtAiSaYQPh6G4sOtr1kg/pL5Z3EDE6rBTV3Se5pMsYvtuwMiSol7MidsQpf4ux9HFhthTO3imcoWImw==}
+    peerDependencies:
+      '@walletconnect/modal': '>=2'
+    peerDependenciesMeta:
+      '@walletconnect/modal':
+        optional: true
+    dependencies:
+      '@walletconnect/jsonrpc-http-connection': 1.0.7
+      '@walletconnect/jsonrpc-provider': 1.0.13
+      '@walletconnect/jsonrpc-types': 1.0.3
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/modal': 2.6.1(react@18.2.0)
+      '@walletconnect/sign-client': 2.10.0
+      '@walletconnect/types': 2.10.0
+      '@walletconnect/universal-provider': 2.10.0
+      '@walletconnect/utils': 2.10.0
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@react-native-async-storage/async-storage'
+      - bufferutil
+      - encoding
+      - lokijs
+      - utf-8-validate
+    dev: false
+
   /@walletconnect/ethereum-provider@2.9.2(@walletconnect/modal@2.6.1):
     resolution: {integrity: sha512-eO1dkhZffV1g7vpG19XUJTw09M/bwGUwwhy1mJ3AOPbOSbMPvwiCuRz2Kbtm1g9B0Jv15Dl+TvJ9vTgYF8zoZg==}
     peerDependencies:
@@ -8026,17 +8153,6 @@ packages:
       tslib: 1.14.1
     dev: false
 
-  /@walletconnect/jsonrpc-http-connection@1.0.5:
-    resolution: {integrity: sha512-4IjbKW+ee7QukDaPyEkfMl4Cu0W0TfzKKiiIzy2lxKkJMmS9EVQOVDV4a9HFuxBqYbfUKiycB7jGkuDTqOedMg==}
-    dependencies:
-      '@walletconnect/jsonrpc-utils': 1.0.6
-      '@walletconnect/safe-json': 1.0.1
-      cross-fetch: 3.1.5
-      tslib: 1.14.1
-    transitivePeerDependencies:
-      - encoding
-    dev: false
-
   /@walletconnect/jsonrpc-http-connection@1.0.7:
     resolution: {integrity: sha512-qlfh8fCfu8LOM9JRR9KE0s0wxP6ZG9/Jom8M0qsoIQeKF3Ni0FyV4V1qy/cc7nfI46SLQLSl4tgWSfLiE1swyQ==}
     dependencies:
@@ -8046,14 +8162,6 @@ packages:
       tslib: 1.14.1
     transitivePeerDependencies:
       - encoding
-    dev: false
-
-  /@walletconnect/jsonrpc-provider@1.0.10:
-    resolution: {integrity: sha512-g0ffPSpY3P6GqGjWGHsr3yqvQUhj7q2k6pAikoXv5XTXWaJRzFvrlbFkSgxziXsBrwrMZn0qvPufvpN4mMZ5FA==}
-    dependencies:
-      '@walletconnect/jsonrpc-utils': 1.0.6
-      '@walletconnect/safe-json': 1.0.1
-      tslib: 1.14.1
     dev: false
 
   /@walletconnect/jsonrpc-provider@1.0.13:
@@ -8075,14 +8183,6 @@ packages:
     resolution: {integrity: sha512-iIQ8hboBl3o5ufmJ8cuduGad0CQm3ZlsHtujv9Eu16xq89q+BG7Nh5VLxxUgmtpnrePgFkTwXirCTkwJH1v+Yw==}
     dependencies:
       keyvaluestorage-interface: 1.0.0
-      tslib: 1.14.1
-    dev: false
-
-  /@walletconnect/jsonrpc-utils@1.0.6:
-    resolution: {integrity: sha512-snp0tfkjPiDLQp/jrBewI+9SM33GPV4+Gjgldod6XQ7rFyQ5FZjnBxUkY4xWH0+arNxzQSi6v5iDXjCjSaorpg==}
-    dependencies:
-      '@walletconnect/environment': 1.0.1
-      '@walletconnect/jsonrpc-types': 1.0.2
       tslib: 1.14.1
     dev: false
 
@@ -8127,10 +8227,10 @@ packages:
     dependencies:
       '@walletconnect/crypto': 1.0.3
       '@walletconnect/encoding': 1.0.2
-      '@walletconnect/jsonrpc-utils': 1.0.6
+      '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/legacy-types': 2.0.0
       '@walletconnect/legacy-utils': 2.0.0
-      '@walletconnect/safe-json': 1.0.1
+      '@walletconnect/safe-json': 1.0.2
       '@walletconnect/window-getters': 1.0.1
       '@walletconnect/window-metadata': 1.0.1
       detect-browser: 5.3.0
@@ -8144,14 +8244,14 @@ packages:
       '@walletconnect/legacy-utils': 2.0.0
       copy-to-clipboard: 3.3.3
       preact: 10.13.2
-      qrcode: 1.5.1
+      qrcode: 1.5.3
     dev: false
 
   /@walletconnect/legacy-provider@2.0.0:
     resolution: {integrity: sha512-A8xPebMI1A+50HbWwTpFCbwP7G+1NGKdTKyg8BUUg3h3Y9JucpC1W6w/x0v1Xw7qFEqQnz74LoIN/A3ytH9xrQ==}
     dependencies:
-      '@walletconnect/jsonrpc-http-connection': 1.0.5
-      '@walletconnect/jsonrpc-provider': 1.0.10
+      '@walletconnect/jsonrpc-http-connection': 1.0.7
+      '@walletconnect/jsonrpc-provider': 1.0.13
       '@walletconnect/legacy-client': 2.0.0
       '@walletconnect/legacy-modal': 2.0.0
       '@walletconnect/legacy-types': 2.0.0
@@ -8163,16 +8263,16 @@ packages:
   /@walletconnect/legacy-types@2.0.0:
     resolution: {integrity: sha512-sOVrA7HUdbI1OwKyPOQU0/DdvTSVFlsXWpAk2K2WvP2erTkBWPMTJq6cv2BmKdoJ3p6gLApT7sd+jHi3OF71uw==}
     dependencies:
-      '@walletconnect/jsonrpc-types': 1.0.2
+      '@walletconnect/jsonrpc-types': 1.0.3
     dev: false
 
   /@walletconnect/legacy-utils@2.0.0:
     resolution: {integrity: sha512-CPWxSVVXw0kgNCxvU126g4GiV3mzXmC8IPJ15twE46aJ1FX+RHEIfAzFMFz2F2+fEhBxL63A7dwNQKDXorRPcQ==}
     dependencies:
       '@walletconnect/encoding': 1.0.2
-      '@walletconnect/jsonrpc-utils': 1.0.6
+      '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/legacy-types': 2.0.0
-      '@walletconnect/safe-json': 1.0.1
+      '@walletconnect/safe-json': 1.0.2
       '@walletconnect/window-getters': 1.0.1
       '@walletconnect/window-metadata': 1.0.1
       detect-browser: 5.3.0
@@ -8253,6 +8353,25 @@ packages:
       tslib: 1.14.1
     dev: false
 
+  /@walletconnect/sign-client@2.10.0:
+    resolution: {integrity: sha512-hbDljDS53kR/It3oXD91UkcOsT6diNnW5+Zzksm0YEfwww5dop/YfNlcdnc8+jKUhWOL/YDPNQCjzsCSNlVzbw==}
+    dependencies:
+      '@walletconnect/core': 2.10.0
+      '@walletconnect/events': 1.0.1
+      '@walletconnect/heartbeat': 1.2.1
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/logger': 2.0.1
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.10.0
+      '@walletconnect/utils': 2.10.0
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@react-native-async-storage/async-storage'
+      - bufferutil
+      - lokijs
+      - utf-8-validate
+    dev: false
+
   /@walletconnect/sign-client@2.9.2:
     resolution: {integrity: sha512-anRwnXKlR08lYllFMEarS01hp1gr6Q9XUgvacr749hoaC/AwGVlxYFdM8+MyYr3ozlA+2i599kjbK/mAebqdXg==}
     dependencies:
@@ -8278,6 +8397,20 @@ packages:
       tslib: 1.14.1
     dev: false
 
+  /@walletconnect/types@2.10.0:
+    resolution: {integrity: sha512-kSTA/WZnbKdEbvbXSW16Ty6dOSzOZCHnGg6JH7q1MuraalD2HuNg00lVVu7QAZ/Rj1Gn9DAkrgP5Wd5a8Xq//Q==}
+    dependencies:
+      '@walletconnect/events': 1.0.1
+      '@walletconnect/heartbeat': 1.2.1
+      '@walletconnect/jsonrpc-types': 1.0.3
+      '@walletconnect/keyvaluestorage': 1.0.2
+      '@walletconnect/logger': 2.0.1
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@react-native-async-storage/async-storage'
+      - lokijs
+    dev: false
+
   /@walletconnect/types@2.9.2:
     resolution: {integrity: sha512-7Rdn30amnJEEal4hk83cdwHUuxI1SWQ+K7fFFHBMqkuHLGi3tpMY6kpyfDxnUScYEZXqgRps4Jo5qQgnRqVM7A==}
     dependencies:
@@ -8290,6 +8423,26 @@ packages:
     transitivePeerDependencies:
       - '@react-native-async-storage/async-storage'
       - lokijs
+    dev: false
+
+  /@walletconnect/universal-provider@2.10.0:
+    resolution: {integrity: sha512-jtVWf+AeTCqBcB3lCmWkv3bvSmdRCkQdo67GNoT5y6/pvVHMxfjgrJNBOUsWQMxpREpWDpZ993X0JRjsYVsMcA==}
+    dependencies:
+      '@walletconnect/jsonrpc-http-connection': 1.0.7
+      '@walletconnect/jsonrpc-provider': 1.0.13
+      '@walletconnect/jsonrpc-types': 1.0.3
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/logger': 2.0.1
+      '@walletconnect/sign-client': 2.10.0
+      '@walletconnect/types': 2.10.0
+      '@walletconnect/utils': 2.10.0
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@react-native-async-storage/async-storage'
+      - bufferutil
+      - encoding
+      - lokijs
+      - utf-8-validate
     dev: false
 
   /@walletconnect/universal-provider@2.9.2:
@@ -8310,6 +8463,28 @@ packages:
       - encoding
       - lokijs
       - utf-8-validate
+    dev: false
+
+  /@walletconnect/utils@2.10.0:
+    resolution: {integrity: sha512-9GRyEz/7CJW+G04RvrjPET5k7hOEsB9b3fF9cWDk/iDCxSWpbkU/hv/urRB36C+gvQMAZgIZYX3dHfzJWkY/2g==}
+    dependencies:
+      '@stablelib/chacha20poly1305': 1.0.1
+      '@stablelib/hkdf': 1.0.1
+      '@stablelib/random': 1.0.2
+      '@stablelib/sha256': 1.0.1
+      '@stablelib/x25519': 1.0.3
+      '@walletconnect/relay-api': 1.0.9
+      '@walletconnect/safe-json': 1.0.2
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.10.0
+      '@walletconnect/window-getters': 1.0.1
+      '@walletconnect/window-metadata': 1.0.1
+      detect-browser: 5.3.0
+      query-string: 7.1.3
+      uint8arrays: 3.1.1
+    transitivePeerDependencies:
+      - '@react-native-async-storage/async-storage'
+      - lokijs
     dev: false
 
   /@walletconnect/utils@2.9.2:
@@ -17094,17 +17269,6 @@ packages:
       - supports-color
       - utf-8-validate
     dev: true
-
-  /qrcode@1.5.1:
-    resolution: {integrity: sha512-nS8NJ1Z3md8uTjKtP+SGGhfqmTCs5flU/xR623oI0JX+Wepz9R8UrRVCTBTJm3qGw3rH6jJ6MUHjkDx15cxSSg==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
-    dependencies:
-      dijkstrajs: 1.0.2
-      encode-utf8: 1.0.3
-      pngjs: 5.0.0
-      yargs: 15.4.1
-    dev: false
 
   /qrcode@1.5.3:
     resolution: {integrity: sha512-puyri6ApkEHYiVl4CFzo1tDkAZ+ATcnbJrJ6RiBM1Fhctdn/ix9MTE3hRph33omisEbC/2fcfemsseiKgBPKZg==}


### PR DESCRIPTION
 - Introduces a new hook `useMulticallTokenBalance`, using viem's multicall functionality to fetch the users token balance.
 - Passes formatted values to `TokenSelector`.

### Notes
 - Even with `multicall` we are asking quite a lot of our public RPC here, and we are sometimes being rate limited by the default wagmi RPC (Cloudflare-eth). This could be a bigger problem once we have multichain support.

### Testing
 - [X] Connecting a wallet and opening the token selector shows token balances.
 - [X] Disconnecting a wallet clears the balances.
 - [X] Loading the page and auto-connecting correctly triggers the balance fetch.
 - [X] Tested FF /w MetaMask and Brave