### PR TITLE
quickswapv3

### DIFF
--- a/packages/hardhat/contracts/facets/UniV3Callback.sol
+++ b/packages/hardhat/contracts/facets/UniV3Callback.sol
@@ -6,15 +6,14 @@ import {SafeERC20} from '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
 import {LibUniV3Like} from '../libraries/LibUniV3Like.sol';
 import {IUniV3Callback} from '../interfaces/IUniV3Callback.sol';
 
+/**
+ * NOTE: Using a shared internal functions uses about 3K more gas than
+ * having two externals with the code duplicated
+ */
 contract UniV3Callback is IUniV3Callback {
   using SafeERC20 for IERC20;
 
-  /**
-   * See https://github.com/Uniswap/v3-periphery/blob/main/contracts/SwapRouter.sol
-   *
-   * NOTE: None of these arguments can be trusted
-   */
-  function uniswapV3SwapCallback(int256, int256, bytes calldata) external {
+  function swapCallback() private {
     if (LibUniV3Like.state().isActive != 1) {
       revert CallbackInactive();
     }
@@ -28,5 +27,21 @@ contract UniV3Callback is IUniV3Callback {
     }
 
     LibUniV3Like.state().isActive = 0;
+  }
+
+  /**
+   * See https://github.com/Uniswap/v3-periphery/blob/main/contracts/SwapRouter.sol
+   *
+   * NOTE: None of these arguments can be trusted
+   */
+  function uniswapV3SwapCallback(int256, int256, bytes calldata) external {
+    swapCallback();
+  }
+
+  /**
+   * NOTE: None of these arguments can be trusted
+   */
+  function algebraSwapCallback(int256, int256, bytes calldata) external {
+    swapCallback();
   }
 }

--- a/packages/hardhat/test/foundry/Curve.t.sol
+++ b/packages/hardhat/test/foundry/Curve.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.19;
 import 'forge-std/Test.sol';
 import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 import {FacetTest} from './helpers/FacetTest.sol';
-import {Mainnet} from './helpers/Mainnet.sol';
+import {Mainnet} from './helpers/Networks.sol';
 import {IDiamondCut} from 'contracts/interfaces/IDiamondCut.sol';
 import {ICurve} from 'contracts/interfaces/ICurve.sol';
 import {Curve} from 'contracts/facets/Curve.sol';

--- a/packages/hardhat/test/foundry/KittyFacet.t.sol
+++ b/packages/hardhat/test/foundry/KittyFacet.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.19;
 import 'forge-std/Test.sol';
 import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 import {FacetTest} from './helpers/FacetTest.sol';
-import {Mainnet} from './helpers/Mainnet.sol';
+import {Mainnet} from './helpers/Networks.sol';
 import {IDiamondCut} from 'contracts/interfaces/IDiamondCut.sol';
 import {IUniV2Router} from 'contracts/interfaces/IUniV2Router.sol';
 import {KittyFacet} from 'contracts/facets/KittyFacet.sol';

--- a/packages/hardhat/test/foundry/LibKitty.t.sol
+++ b/packages/hardhat/test/foundry/LibKitty.t.sol
@@ -6,7 +6,7 @@ pragma solidity 0.8.19;
 import 'forge-std/Test.sol';
 import {EnumerableSet} from '@openzeppelin/contracts/utils/structs/EnumerableSet.sol';
 import {LibKitty} from 'contracts/libraries/LibKitty.sol';
-import {Mainnet} from './helpers/Mainnet.sol';
+import {Mainnet} from './helpers/Networks.sol';
 
 contract LibKittyTest is Test {
   using EnumerableSet for EnumerableSet.AddressSet;

--- a/packages/hardhat/test/foundry/SifiDiamond.t.sol
+++ b/packages/hardhat/test/foundry/SifiDiamond.t.sol
@@ -8,7 +8,6 @@ import {IDiamondCut} from 'contracts/interfaces/IDiamondCut.sol';
 import {DiamondLoupeFacet} from 'contracts/facets/DiamondLoupeFacet.sol';
 import {OwnershipFacet} from 'contracts/facets/OwnershipFacet.sol';
 import {LibDiamond} from 'contracts/libraries/LibDiamond.sol';
-import {Mainnet} from './helpers/Mainnet.sol';
 
 contract SifiDiamondHarness is SifiDiamond {
   constructor(

--- a/packages/hardhat/test/foundry/UniV2LikeFacet.t.sol
+++ b/packages/hardhat/test/foundry/UniV2LikeFacet.t.sol
@@ -3,9 +3,7 @@ pragma solidity ^0.8.19;
 
 import 'forge-std/Test.sol';
 import {FacetTest} from './helpers/FacetTest.sol';
-import {Mainnet} from './helpers/Mainnet.sol';
-import {Arbitrum} from './helpers/Arbitrum.sol';
-import {Polygon} from './helpers/Polygon.sol';
+import {Addresses, Mainnet, Arbitrum} from './helpers/Networks.sol';
 import {IDiamondCut} from 'contracts/interfaces/IDiamondCut.sol';
 import {IUniV2Like} from 'contracts/interfaces/IUniV2Like.sol';
 import {UniV2LikeFacet} from 'contracts/facets/UniV2LikeFacet.sol';
@@ -39,22 +37,10 @@ contract UniV2LikeFacetTestBase is FacetTest {
       generateSelectors('UniV2LikeFacet')
     );
 
-    address weth;
-
-    if (chainId == 1) {
-      weth = address(Mainnet.WETH);
-    } else if (chainId == 137) {
-      weth = address(Polygon.WMATIC);
-    } else if (chainId == 42161) {
-      weth = address(Arbitrum.WETH);
-    } else {
-      revert('Unsupported chain');
-    }
-
     IDiamondCut(address(diamond)).diamondCut(
       facetCuts,
       address(new InitLibWarp()),
-      abi.encodeWithSelector(InitLibWarp.init.selector, weth)
+      abi.encodeWithSelector(InitLibWarp.init.selector, Addresses.weth(chainId))
     );
 
     facet = IUniV2Like(address(diamond));

--- a/packages/hardhat/test/foundry/UniV2RouterFacet.int.t.sol
+++ b/packages/hardhat/test/foundry/UniV2RouterFacet.int.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.19;
 import 'forge-std/Test.sol';
 import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 import {FacetTest} from './helpers/FacetTest.sol';
-import {Mainnet} from './helpers/Mainnet.sol';
+import {Mainnet} from './helpers/Networks.sol';
 import {IDiamondCut} from 'contracts/interfaces/IDiamondCut.sol';
 import {IUniV2Router} from 'contracts/interfaces/IUniV2Router.sol';
 import {UniV2RouterFacet} from 'contracts/facets/UniV2RouterFacet.sol';

--- a/packages/hardhat/test/foundry/UniV2RouterFacet.t.sol
+++ b/packages/hardhat/test/foundry/UniV2RouterFacet.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.19;
 
 import 'forge-std/Test.sol';
 import {FacetTest} from './helpers/FacetTest.sol';
-import {Mainnet} from './helpers/Mainnet.sol';
+import {Mainnet} from './helpers/Networks.sol';
 import {IDiamondCut} from 'contracts/interfaces/IDiamondCut.sol';
 import {IUniV2Router} from 'contracts/interfaces/IUniV2Router.sol';
 import {UniV2RouterFacet} from 'contracts/facets/UniV2RouterFacet.sol';

--- a/packages/hardhat/test/foundry/UniV3Like.t.sol
+++ b/packages/hardhat/test/foundry/UniV3Like.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.19;
 
 import 'forge-std/Test.sol';
 import {FacetTest} from './helpers/FacetTest.sol';
-import {Mainnet} from './helpers/Mainnet.sol';
+import {Mainnet} from './helpers/Networks.sol';
 import {IDiamondCut} from 'contracts/interfaces/IDiamondCut.sol';
 import {IUniV3Like} from 'contracts/interfaces/IUniV3Like.sol';
 import {UniV3Like} from 'contracts/facets/UniV3Like.sol';

--- a/packages/hardhat/test/foundry/WarpLink.t.sol
+++ b/packages/hardhat/test/foundry/WarpLink.t.sol
@@ -13,9 +13,7 @@ import {InitLibWarp} from 'contracts/init/InitLibWarp.sol';
 import {IUniswapV2Factory} from 'contracts/interfaces/external/IUniswapV2Factory.sol';
 import {FacetTest} from './helpers/FacetTest.sol';
 import {UniV3Callback} from 'contracts/facets/UniV3Callback.sol';
-import {Mainnet} from './helpers/Mainnet.sol';
-import {Polygon} from './helpers/Polygon.sol';
-import {Arbitrum} from './helpers/Arbitrum.sol';
+import {Addresses, Mainnet, Polygon, Arbitrum} from './helpers/Networks.sol';
 import {WarpLinkEncoder} from './helpers/WarpLinkEncoder.sol';
 
 contract WarpLinkTestBase is FacetTest {
@@ -51,24 +49,12 @@ contract WarpLinkTestBase is FacetTest {
       generateSelectors('WarpLink')
     );
 
-    address weth;
-
-    if (chainId == 1) {
-      weth = address(Mainnet.WETH);
-    } else if (chainId == 137) {
-      weth = address(Polygon.WMATIC);
-    } else if (chainId == 42161) {
-      weth = address(Arbitrum.WETH);
-    } else {
-      revert('Unsupported chain');
-    }
-
     InitLibWarp initLibWarp = new InitLibWarp();
 
     IDiamondCut(address(diamond)).diamondCut(
       facetCuts,
       address(initLibWarp),
-      abi.encodeWithSelector(initLibWarp.init.selector, weth)
+      abi.encodeWithSelector(initLibWarp.init.selector, Addresses.weth(chainId))
     );
 
     facet = WarpLink(address(diamond));

--- a/packages/hardhat/test/foundry/helpers/Arbitrum.sol
+++ b/packages/hardhat/test/foundry/helpers/Arbitrum.sol
@@ -1,6 +1,0 @@
-import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
-
-library Arbitrum {
-  IERC20 public constant WETH = IERC20(0x82aF49447D8a07e3bd95BD0d56f35241523fBab1);
-  IERC20 public constant USDC = IERC20(0xaf88d065e77c8cC2239327C5EDb3A432268e5831);
-}

--- a/packages/hardhat/test/foundry/helpers/FacetTest.sol
+++ b/packages/hardhat/test/foundry/helpers/FacetTest.sol
@@ -9,13 +9,13 @@ import {IDiamondCut} from 'contracts/interfaces/IDiamondCut.sol';
 import {DiamondLoupeFacet} from 'contracts/facets/DiamondLoupeFacet.sol';
 import {OwnershipFacet} from 'contracts/facets/OwnershipFacet.sol';
 import {LibDiamond} from 'contracts/libraries/LibDiamond.sol';
-import {Mainnet} from './Mainnet.sol';
+import {Mainnet} from './Networks.sol';
 
 abstract contract FacetTest is DiamondHelpers {
   SifiDiamond internal diamond;
 
   function setUp() public virtual {
-    setUpOn(1, 17853419);
+    setUpOn(Mainnet.CHAIN_ID, 17853419);
   }
 
   function setUpOn(uint256 chainId, uint256 blockNumber) internal virtual {

--- a/packages/hardhat/test/foundry/helpers/Networks.sol
+++ b/packages/hardhat/test/foundry/helpers/Networks.sol
@@ -28,6 +28,7 @@ library Polygon {
   uint256 public constant CHAIN_ID = 137;
   IERC20 public constant WMATIC = IERC20(0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270);
   IERC20 public constant USDC = IERC20(0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174);
+  IERC20 public constant USDT = IERC20(0xc2132D05D31c914a87C6611C10748AEb04B58e8F);
 }
 
 library Addresses {

--- a/packages/hardhat/test/foundry/helpers/Networks.sol
+++ b/packages/hardhat/test/foundry/helpers/Networks.sol
@@ -1,6 +1,7 @@
 import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 
 library Mainnet {
+  uint256 public constant CHAIN_ID = 1;
   IERC20 public constant WETH = IERC20(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
   IERC20 public constant USDC = IERC20(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48);
   IERC20 public constant USDT = IERC20(0xdAC17F958D2ee523a2206206994597C13D831ec7);
@@ -15,4 +16,30 @@ library Mainnet {
   address public constant UNISWAP_V2_FACTORY_ADDR = 0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f;
   address public constant SUSHISWAP_V2_FACTORY = 0xC0AEe478e3658e2610c5F7A4A2E1777cE9e4f2Ac;
   address public constant PANCAKESWAP_V2_FACTORY = 0x1097053Fd2ea711dad45caCcc45EfF7548fCB362;
+}
+
+library Arbitrum {
+  uint256 public constant CHAIN_ID = 42161;
+  IERC20 public constant WETH = IERC20(0x82aF49447D8a07e3bd95BD0d56f35241523fBab1);
+  IERC20 public constant USDC = IERC20(0xaf88d065e77c8cC2239327C5EDb3A432268e5831);
+}
+
+library Polygon {
+  uint256 public constant CHAIN_ID = 137;
+  IERC20 public constant WMATIC = IERC20(0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270);
+  IERC20 public constant USDC = IERC20(0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174);
+}
+
+library Addresses {
+  function weth(uint256 chainId) internal pure returns (IERC20) {
+    if (chainId == Mainnet.CHAIN_ID) {
+      return Mainnet.WETH;
+    } else if (chainId == Arbitrum.CHAIN_ID) {
+      return Arbitrum.WETH;
+    } else if (chainId == Polygon.CHAIN_ID) {
+      return Polygon.WMATIC;
+    } else {
+      revert('Unsupported chain');
+    }
+  }
 }

--- a/packages/hardhat/test/foundry/helpers/Polygon.sol
+++ b/packages/hardhat/test/foundry/helpers/Polygon.sol
@@ -1,6 +1,0 @@
-import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
-
-library Polygon {
-  IERC20 public constant WMATIC = IERC20(0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270);
-  IERC20 public constant USDC = IERC20(0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174);
-}


### PR DESCRIPTION
This PR adds support for Algebra, which is used by QuickSwap V3 on Polygon. Yes, they renamed the callback.

- refactor(hardhat): extract Networks test helper
- feat(hardhat): support algebra for univ3

![image](https://github.com/sideshiftfi/sifi/assets/128569957/71e36319-1812-49cd-8a33-b65737d7b4c7)
