### PR TITLE
feat(frontend): use short viem error messages

### DIFF
--- a/packages/frontend/src/components/ConnectWallet/ConnectWallet.tsx
+++ b/packages/frontend/src/components/ConnectWallet/ConnectWallet.tsx
@@ -5,6 +5,7 @@ import useConnectWallet from 'src/hooks/useConnectWallet';
 import closeIcon from 'src/assets/icons/close.svg';
 import { type SupportedWallet } from 'src/connectors';
 import { Button } from '../Button';
+import { getViemErrorMessage } from 'src/utils';
 
 const supportedWallets: SupportedWallet[] = ['injected', 'coinbase', 'walletconnect'];
 
@@ -21,7 +22,7 @@ const ConnectWalletModal: FunctionComponent<ConnectWalletModalProps> = ({
 
   useEffect(() => {
     if (error) {
-      showToast({ text: error.message, type: 'error' });
+      showToast({ text: getViemErrorMessage(error), type: 'error' });
     }
   }, [error]);
 

--- a/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
+++ b/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
@@ -7,7 +7,7 @@ import { useTokens } from 'src/hooks/useTokens';
 import { useTokenBalance } from 'src/hooks/useTokenBalance';
 import { useMutation } from '@tanstack/react-query';
 import { useSifi } from 'src/providers/SDKProvider';
-import { getEvmTxUrl, getTokenBySymbol, parseErrorMessage } from 'src/utils';
+import { getEvmTxUrl, getTokenBySymbol, getViemErrorMessage, parseErrorMessage } from 'src/utils';
 import { SwapFormKey, SwapFormKeyHelper } from 'src/providers/SwapFormProvider';
 import { useCullQueries } from 'src/hooks/useCullQueries';
 import { useQuote } from 'src/hooks/useQuote';
@@ -63,7 +63,7 @@ const CreateSwap = () => {
     {
       onError: error => {
         if (error instanceof Error) {
-          showToast({ text: parseErrorMessage(error.message), type: 'error' });
+          showToast({ text: getViemErrorMessage(error), type: 'error' });
         } else {
           console.error(error);
         }

--- a/packages/frontend/src/components/CreateSwapButtons/ApproveButton.tsx
+++ b/packages/frontend/src/components/CreateSwapButtons/ApproveButton.tsx
@@ -5,6 +5,7 @@ import { useAllowance } from 'src/hooks/useAllowance';
 import { SwapFormKey } from 'src/providers/SwapFormProvider';
 import { ApprovalModal } from 'src/modals';
 import { Button } from '../Button';
+import { getViemErrorMessage } from 'src/utils';
 
 const ApproveButton = () => {
   const {
@@ -27,7 +28,7 @@ const ApproveButton = () => {
     } catch (error) {
       closeModal();
       if (error instanceof Error) {
-        showToast({ type: 'error', text: error.message });
+        showToast({ type: 'error', text: getViemErrorMessage(error) });
       } else {
         console.error(error);
       }

--- a/packages/frontend/src/types.ts
+++ b/packages/frontend/src/types.ts
@@ -1,6 +1,9 @@
 import type { Token } from "@sifi/sdk";
+import type { BaseError } from 'viem';
 
 type MulticallToken = Omit<Token, 'address'> & { address: `0x${string}` };
 type BalanceMap = Map<`0x${string}`, string>;
 
-export type { MulticallToken, BalanceMap };
+type ViemError = Error | (Error & BaseError);
+
+export type { MulticallToken, BalanceMap, ViemError };

--- a/packages/frontend/src/utils/getViemErrorMessage.ts
+++ b/packages/frontend/src/utils/getViemErrorMessage.ts
@@ -1,0 +1,16 @@
+import { ViemError } from "src/types";
+import { parseErrorMessage } from "./parseErrorMessage";
+
+const getViemErrorMessage = (error: ViemError): string => {
+  let message = 'An error occurred';
+
+  if ('shortMessage' in error) {
+    message = error.shortMessage;
+  } else if (error.message) {
+    message = error.message;
+  }
+
+  return parseErrorMessage(message);
+};
+
+export { getViemErrorMessage };

--- a/packages/frontend/src/utils/index.ts
+++ b/packages/frontend/src/utils/index.ts
@@ -6,3 +6,4 @@ export * from './api';
 export * from './parseErrorMessage';
 export * from './evm';
 export * from './isValidTokenAmount';
+export * from './getViemErrorMessage';

--- a/packages/frontend/src/utils/parseErrorMessage.ts
+++ b/packages/frontend/src/utils/parseErrorMessage.ts
@@ -1,5 +1,5 @@
 const parseErrorMessage = (message: string) => {
-  if (message.includes('user rejected transaction')) {
+  if (message.toLowerCase().includes('user rejected the request')) {
     return 'You rejected the transaction';
   }
 


### PR DESCRIPTION
 - Uses Viem `shortMessage` field in toasts if it exists on a given error message.
 - Changes message filter in existing error filtering function to match phrasing used in Viem error messages.
 - Applies fix to token approval, and transaction sending.

![image](https://github.com/sideshiftfi/sifi/assets/112887817/9fa1f296-06c6-40be-8a93-63c8c178c62a)
