### PR TITLE
temp(monorepo): disable foundry tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,8 +76,9 @@ jobs:
       - name: Foundry forge build
         run: pnpm -C packages/hardhat forge-build
 
-      - name: Foundry forge test
-        run: pnpm -C packages/hardhat forge-test
+      # Temporarily disabled until fixed
+      # - name: Foundry forge test
+      #   run: pnpm -C packages/hardhat forge-test
 
       - name: Slither analyze
         id: slither


### PR DESCRIPTION
Temporarily disables Foundry Tests until #221 is fixed to avoid blocking