### PR TITLE
fix(frontend): don't use default fromAmount

### DIFF
--- a/packages/frontend/src/providers/SwapFormProvider.tsx
+++ b/packages/frontend/src/providers/SwapFormProvider.tsx
@@ -25,7 +25,7 @@ export type SwapFormValues = {
 export type SwapFormType = 'from' | 'to';
 
 export const formDefaultValues = {
-  [SwapFormKey.FromAmount]: '1',
+  [SwapFormKey.FromAmount]: '',
   [SwapFormKey.FromChain]: 1, // Temporarily restricted ot ETH chain
   [SwapFormKey.FromToken]: null,
   [SwapFormKey.ToAmount]: '',


### PR DESCRIPTION
Removes the default `fromAmount` value, so that the user is presented with empty input fields and a visible Max button.

<img width="527" alt="image" src="https://github.com/sideshiftfi/sifi/assets/128667801/ff7b9442-f539-4749-8940-5ebf75826def">

--

This fixes the issue of welcoming users with a max error and insufficient balance states.

Previously, when arriving to the app:
<img width="521" alt="image" src="https://github.com/sideshiftfi/sifi/assets/128667801/9ab7de5e-86e0-4f66-9802-a718f9b7b0ca">

Autofocus on `fromAmount` might be nice, but ShiftInput does not support it yet.