### PR TITLE
feat(hardhat): permit2

### DIFF
--- a/packages/hardhat/contracts/facets/UniV3Callback.sol
+++ b/packages/hardhat/contracts/facets/UniV3Callback.sol
@@ -4,7 +4,9 @@ pragma solidity 0.8.19;
 import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 import {SafeERC20} from '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
 import {LibUniV3Like} from '../libraries/LibUniV3Like.sol';
+import {LibWarp} from '../libraries/LibWarp.sol';
 import {IUniV3Callback} from '../interfaces/IUniV3Callback.sol';
+import {IPermit2} from '../interfaces/external/IPermit2.sol';
 
 /**
  * NOTE: Using a shared internal functions uses about 3K more gas than
@@ -23,7 +25,12 @@ contract UniV3Callback is IUniV3Callback {
     if (callback.payer == address(this)) {
       IERC20(callback.token).safeTransfer(msg.sender, callback.amount);
     } else {
-      IERC20(callback.token).safeTransferFrom(callback.payer, msg.sender, callback.amount);
+      LibWarp.state().permit2.transferFrom(
+        callback.payer,
+        msg.sender,
+        (uint160)(callback.amount),
+        callback.token
+      );
     }
 
     LibUniV3Like.state().isActive = 0;

--- a/packages/hardhat/contracts/init/InitLibWarp.sol
+++ b/packages/hardhat/contracts/init/InitLibWarp.sol
@@ -3,11 +3,13 @@ pragma solidity 0.8.19;
 
 import {IWETH} from '@uniswap/v2-periphery/contracts/interfaces/IWETH.sol';
 import {LibWarp} from '../libraries/LibWarp.sol';
+import {IPermit2} from '../interfaces/external/IPermit2.sol';
 
 contract InitLibWarp {
-  function init(address weth) public {
+  function init(address weth, address permit2) public {
     LibWarp.State storage s = LibWarp.state();
 
     s.weth = IWETH(weth);
+    s.permit2 = IPermit2(permit2);
   }
 }

--- a/packages/hardhat/contracts/init/InitUniV2Router.sol
+++ b/packages/hardhat/contracts/init/InitUniV2Router.sol
@@ -5,15 +5,17 @@ import {IWETH} from '@uniswap/v2-periphery/contracts/interfaces/IWETH.sol';
 import {IUniswapV2Router02} from '@uniswap/v2-periphery/contracts/interfaces/IUniswapV2Router02.sol';
 import {LibDiamond} from '../libraries/LibDiamond.sol';
 import {LibUniV2Router} from '../libraries/LibUniV2Router.sol';
+import {IPermit2} from '../interfaces/external/IPermit2.sol';
 
 contract InitUniV2Router {
-  function init(address uniswapV2Router02, address uniswapV2Factory) public {
+  function init(address uniswapV2Router02, address uniswapV2Factory, address permit2) public {
     LibUniV2Router.DiamondStorage storage s = LibUniV2Router.diamondStorage();
 
     if (!s.isInitialized) {
       s.isInitialized = true;
       s.uniswapV2router02 = IUniswapV2Router02(uniswapV2Router02);
       s.weth = IWETH(s.uniswapV2router02.WETH());
+      s.permit2 = IPermit2(permit2);
     }
 
     s.uniswapV2Factory = uniswapV2Factory;

--- a/packages/hardhat/contracts/interfaces/ICurve.sol
+++ b/packages/hardhat/contracts/interfaces/ICurve.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.19;
 
+import {PermitParams} from '../libraries/PermitParams.sol';
+
 interface ICurve {
   error DeadlineExpired();
   error InsufficientOutputAmount();
@@ -24,6 +26,7 @@ interface ICurve {
   }
 
   function curveExactInputSingle(
-    ExactInputSingleParams memory params
+    ExactInputSingleParams memory params,
+    PermitParams calldata permit
   ) external payable returns (uint256 amountOut);
 }

--- a/packages/hardhat/contracts/interfaces/IUniV2Like.sol
+++ b/packages/hardhat/contracts/interfaces/IUniV2Like.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.19;
 
+import {PermitParams} from '../libraries/PermitParams.sol';
+
 interface IUniV2Like {
   error InsufficienTokensDelivered();
   error DeadlineExpired();
@@ -36,10 +38,12 @@ interface IUniV2Like {
   }
 
   function uniswapV2LikeExactInputSingle(
-    ExactInputSingleParams memory params
+    ExactInputSingleParams memory params,
+    PermitParams calldata permit
   ) external payable returns (uint256 amountOut);
 
   function uniswapV2LikeExactInput(
-    ExactInputParams memory params
+    ExactInputParams memory params,
+    PermitParams calldata permit
   ) external payable returns (uint256 amountOut);
 }

--- a/packages/hardhat/contracts/interfaces/IUniV2Router.sol
+++ b/packages/hardhat/contracts/interfaces/IUniV2Router.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.19;
 
+import {PermitParams} from '../libraries/PermitParams.sol';
+
 interface IUniV2Router {
   struct ExactInputParams {
     uint256 amountIn;
@@ -26,10 +28,12 @@ interface IUniV2Router {
   }
 
   function uniswapV2ExactInputSingle(
-    ExactInputSingleParams memory params
+    ExactInputSingleParams memory params,
+    PermitParams calldata permit
   ) external payable returns (uint256 amountOut);
 
   function uniswapV2ExactInput(
-    ExactInputParams memory params
+    ExactInputParams memory params,
+    PermitParams calldata permit
   ) external payable returns (uint256 amountOut);
 }

--- a/packages/hardhat/contracts/interfaces/IUniV3Like.sol
+++ b/packages/hardhat/contracts/interfaces/IUniV3Like.sol
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.19;
 
+import {IAllowanceTransfer} from '../interfaces/external/IAllowanceTransfer.sol';
+import {PermitParams} from '../libraries/PermitParams.sol';
+
 interface IUniV3Like {
   error InsufficienTokensDelivered();
   error DeadlineExpired();
@@ -34,10 +37,12 @@ interface IUniV3Like {
   }
 
   function uniswapV3LikeExactInputSingle(
-    ExactInputSingleParams memory params
+    ExactInputSingleParams memory params,
+    PermitParams calldata permit
   ) external payable returns (uint256 amountOut);
 
   function uniswapV3LikeExactInput(
-    ExactInputParams memory params
+    ExactInputParams memory params,
+    PermitParams calldata permit
   ) external payable returns (uint256 amountOut);
 }

--- a/packages/hardhat/contracts/interfaces/IWarpLink.sol
+++ b/packages/hardhat/contracts/interfaces/IWarpLink.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.19;
 
+import {PermitParams} from '../libraries/PermitParams.sol';
+
 interface IWarpLink {
   error UnhandledCommand();
   error IncorrectEthValue();
@@ -37,7 +39,7 @@ interface IWarpLink {
     bytes commands;
   }
 
-  function warpLinkEngage(Params memory params) external payable;
+  function warpLinkEngage(Params memory params, PermitParams calldata permit) external payable;
 
   function commandTypeWrap() external pure returns (uint256);
 

--- a/packages/hardhat/contracts/interfaces/external/IAllowanceTransfer.sol
+++ b/packages/hardhat/contracts/interfaces/external/IAllowanceTransfer.sol
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import {IEIP712} from './IEIP712.sol';
+
+/// @title AllowanceTransfer
+/// @notice Handles ERC20 token permissions through signature based allowance setting and ERC20 token transfers by checking allowed amounts
+/// @dev Requires user's token approval on the Permit2 contract
+interface IAllowanceTransfer is IEIP712 {
+  /// @notice Thrown when an allowance on a token has expired.
+  /// @param deadline The timestamp at which the allowed amount is no longer valid
+  error AllowanceExpired(uint256 deadline);
+
+  /// @notice Thrown when an allowance on a token has been depleted.
+  /// @param amount The maximum amount allowed
+  error InsufficientAllowance(uint256 amount);
+
+  /// @notice Thrown when too many nonces are invalidated.
+  error ExcessiveInvalidation();
+
+  /// @notice Emits an event when the owner successfully invalidates an ordered nonce.
+  event NonceInvalidation(
+    address indexed owner,
+    address indexed token,
+    address indexed spender,
+    uint48 newNonce,
+    uint48 oldNonce
+  );
+
+  /// @notice Emits an event when the owner successfully sets permissions on a token for the spender.
+  event Approval(
+    address indexed owner,
+    address indexed token,
+    address indexed spender,
+    uint160 amount,
+    uint48 expiration
+  );
+
+  /// @notice Emits an event when the owner successfully sets permissions using a permit signature on a token for the spender.
+  event Permit(
+    address indexed owner,
+    address indexed token,
+    address indexed spender,
+    uint160 amount,
+    uint48 expiration,
+    uint48 nonce
+  );
+
+  /// @notice Emits an event when the owner sets the allowance back to 0 with the lockdown function.
+  event Lockdown(address indexed owner, address token, address spender);
+
+  /// @notice The permit data for a token
+  struct PermitDetails {
+    // ERC20 token address
+    address token;
+    // the maximum amount allowed to spend
+    uint160 amount;
+    // timestamp at which a spender's token allowances become invalid
+    uint48 expiration;
+    // an incrementing value indexed per owner,token,and spender for each signature
+    uint48 nonce;
+  }
+
+  /// @notice The permit message signed for a single token allownce
+  struct PermitSingle {
+    // the permit data for a single token alownce
+    PermitDetails details;
+    // address permissioned on the allowed tokens
+    address spender;
+    // deadline on the permit signature
+    uint256 sigDeadline;
+  }
+
+  /// @notice The permit message signed for multiple token allowances
+  struct PermitBatch {
+    // the permit data for multiple token allowances
+    PermitDetails[] details;
+    // address permissioned on the allowed tokens
+    address spender;
+    // deadline on the permit signature
+    uint256 sigDeadline;
+  }
+
+  /// @notice The saved permissions
+  /// @dev This info is saved per owner, per token, per spender and all signed over in the permit message
+  /// @dev Setting amount to type(uint160).max sets an unlimited approval
+  struct PackedAllowance {
+    // amount allowed
+    uint160 amount;
+    // permission expiry
+    uint48 expiration;
+    // an incrementing value indexed per owner,token,and spender for each signature
+    uint48 nonce;
+  }
+
+  /// @notice A token spender pair.
+  struct TokenSpenderPair {
+    // the token the spender is approved
+    address token;
+    // the spender address
+    address spender;
+  }
+
+  /// @notice Details for a token transfer.
+  struct AllowanceTransferDetails {
+    // the owner of the token
+    address from;
+    // the recipient of the token
+    address to;
+    // the amount of the token
+    uint160 amount;
+    // the token to be transferred
+    address token;
+  }
+
+  /// @notice A mapping from owner address to token address to spender address to PackedAllowance struct, which contains details and conditions of the approval.
+  /// @notice The mapping is indexed in the above order see: allowance[ownerAddress][tokenAddress][spenderAddress]
+  /// @dev The packed slot holds the allowed amount, expiration at which the allowed amount is no longer valid, and current nonce thats updated on any signature based approvals.
+  function allowance(
+    address user,
+    address token,
+    address spender
+  ) external view returns (uint160 amount, uint48 expiration, uint48 nonce);
+
+  /// @notice Approves the spender to use up to amount of the specified token up until the expiration
+  /// @param token The token to approve
+  /// @param spender The spender address to approve
+  /// @param amount The approved amount of the token
+  /// @param expiration The timestamp at which the approval is no longer valid
+  /// @dev The packed allowance also holds a nonce, which will stay unchanged in approve
+  /// @dev Setting amount to type(uint160).max sets an unlimited approval
+  function approve(address token, address spender, uint160 amount, uint48 expiration) external;
+
+  /// @notice Permit a spender to a given amount of the owners token via the owner's EIP-712 signature
+  /// @dev May fail if the owner's nonce was invalidated in-flight by invalidateNonce
+  /// @param owner The owner of the tokens being approved
+  /// @param permitSingle Data signed over by the owner specifying the terms of approval
+  /// @param signature The owner's signature over the permit data
+  function permit(
+    address owner,
+    PermitSingle memory permitSingle,
+    bytes calldata signature
+  ) external;
+
+  /// @notice Permit a spender to the signed amounts of the owners tokens via the owner's EIP-712 signature
+  /// @dev May fail if the owner's nonce was invalidated in-flight by invalidateNonce
+  /// @param owner The owner of the tokens being approved
+  /// @param permitBatch Data signed over by the owner specifying the terms of approval
+  /// @param signature The owner's signature over the permit data
+  function permit(address owner, PermitBatch memory permitBatch, bytes calldata signature) external;
+
+  /// @notice Transfer approved tokens from one address to another
+  /// @param from The address to transfer from
+  /// @param to The address of the recipient
+  /// @param amount The amount of the token to transfer
+  /// @param token The token address to transfer
+  /// @dev Requires the from address to have approved at least the desired amount
+  /// of tokens to msg.sender.
+  function transferFrom(address from, address to, uint160 amount, address token) external;
+
+  /// @notice Transfer approved tokens in a batch
+  /// @param transferDetails Array of owners, recipients, amounts, and tokens for the transfers
+  /// @dev Requires the from addresses to have approved at least the desired amount
+  /// of tokens to msg.sender.
+  function transferFrom(AllowanceTransferDetails[] calldata transferDetails) external;
+
+  /// @notice Enables performing a "lockdown" of the sender's Permit2 identity
+  /// by batch revoking approvals
+  /// @param approvals Array of approvals to revoke.
+  function lockdown(TokenSpenderPair[] calldata approvals) external;
+
+  /// @notice Invalidate nonces for a given (token, spender) pair
+  /// @param token The token to invalidate nonces for
+  /// @param spender The spender to invalidate nonces for
+  /// @param newNonce The new nonce to set. Invalidates all nonces less than it.
+  /// @dev Can't invalidate more than 2**16 nonces per transaction.
+  function invalidateNonces(address token, address spender, uint48 newNonce) external;
+}

--- a/packages/hardhat/contracts/interfaces/external/IEIP712.sol
+++ b/packages/hardhat/contracts/interfaces/external/IEIP712.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+interface IEIP712 {
+  function DOMAIN_SEPARATOR() external view returns (bytes32);
+}

--- a/packages/hardhat/contracts/interfaces/external/IPermit2.sol
+++ b/packages/hardhat/contracts/interfaces/external/IPermit2.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {ISignatureTransfer} from './ISignatureTransfer.sol';
+import {IAllowanceTransfer} from './IAllowanceTransfer.sol';
+
+/// @notice Permit2 handles signature-based transfers in SignatureTransfer and allowance-based transfers in AllowanceTransfer.
+/// @dev Users must approve Permit2 before calling any of the transfer functions.
+interface IPermit2 is ISignatureTransfer, IAllowanceTransfer {
+  // IPermit2 unifies the two interfaces so users have maximal flexibility with their approval.
+}

--- a/packages/hardhat/contracts/interfaces/external/ISignatureTransfer.sol
+++ b/packages/hardhat/contracts/interfaces/external/ISignatureTransfer.sol
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import {IEIP712} from './IEIP712.sol';
+
+/// @title SignatureTransfer
+/// @notice Handles ERC20 token transfers through signature based actions
+/// @dev Requires user's token approval on the Permit2 contract
+interface ISignatureTransfer is IEIP712 {
+  /// @notice Thrown when the requested amount for a transfer is larger than the permissioned amount
+  /// @param maxAmount The maximum amount a spender can request to transfer
+  error InvalidAmount(uint256 maxAmount);
+
+  /// @notice Thrown when the number of tokens permissioned to a spender does not match the number of tokens being transferred
+  /// @dev If the spender does not need to transfer the number of tokens permitted, the spender can request amount 0 to be transferred
+  error LengthMismatch();
+
+  /// @notice Emits an event when the owner successfully invalidates an unordered nonce.
+  event UnorderedNonceInvalidation(address indexed owner, uint256 word, uint256 mask);
+
+  /// @notice The token and amount details for a transfer signed in the permit transfer signature
+  struct TokenPermissions {
+    // ERC20 token address
+    address token;
+    // the maximum amount that can be spent
+    uint256 amount;
+  }
+
+  /// @notice The signed permit message for a single token transfer
+  struct PermitTransferFrom {
+    TokenPermissions permitted;
+    // a unique value for every token owner's signature to prevent signature replays
+    uint256 nonce;
+    // deadline on the permit signature
+    uint256 deadline;
+  }
+
+  /// @notice Specifies the recipient address and amount for batched transfers.
+  /// @dev Recipients and amounts correspond to the index of the signed token permissions array.
+  /// @dev Reverts if the requested amount is greater than the permitted signed amount.
+  struct SignatureTransferDetails {
+    // recipient address
+    address to;
+    // spender requested amount
+    uint256 requestedAmount;
+  }
+
+  /// @notice Used to reconstruct the signed permit message for multiple token transfers
+  /// @dev Do not need to pass in spender address as it is required that it is msg.sender
+  /// @dev Note that a user still signs over a spender address
+  struct PermitBatchTransferFrom {
+    // the tokens and corresponding amounts permitted for a transfer
+    TokenPermissions[] permitted;
+    // a unique value for every token owner's signature to prevent signature replays
+    uint256 nonce;
+    // deadline on the permit signature
+    uint256 deadline;
+  }
+
+  /// @notice A map from token owner address and a caller specified word index to a bitmap. Used to set bits in the bitmap to prevent against signature replay protection
+  /// @dev Uses unordered nonces so that permit messages do not need to be spent in a certain order
+  /// @dev The mapping is indexed first by the token owner, then by an index specified in the nonce
+  /// @dev It returns a uint256 bitmap
+  /// @dev The index, or wordPosition is capped at type(uint248).max
+  function nonceBitmap(address, uint256) external view returns (uint256);
+
+  /// @notice Transfers a token using a signed permit message
+  /// @dev Reverts if the requested amount is greater than the permitted signed amount
+  /// @param permit The permit data signed over by the owner
+  /// @param owner The owner of the tokens to transfer
+  /// @param transferDetails The spender's requested transfer details for the permitted token
+  /// @param signature The signature to verify
+  function permitTransferFrom(
+    PermitTransferFrom memory permit,
+    SignatureTransferDetails calldata transferDetails,
+    address owner,
+    bytes calldata signature
+  ) external;
+
+  /// @notice Transfers a token using a signed permit message
+  /// @notice Includes extra data provided by the caller to verify signature over
+  /// @dev The witness type string must follow EIP712 ordering of nested structs and must include the TokenPermissions type definition
+  /// @dev Reverts if the requested amount is greater than the permitted signed amount
+  /// @param permit The permit data signed over by the owner
+  /// @param owner The owner of the tokens to transfer
+  /// @param transferDetails The spender's requested transfer details for the permitted token
+  /// @param witness Extra data to include when checking the user signature
+  /// @param witnessTypeString The EIP-712 type definition for remaining string stub of the typehash
+  /// @param signature The signature to verify
+  function permitWitnessTransferFrom(
+    PermitTransferFrom memory permit,
+    SignatureTransferDetails calldata transferDetails,
+    address owner,
+    bytes32 witness,
+    string calldata witnessTypeString,
+    bytes calldata signature
+  ) external;
+
+  /// @notice Transfers multiple tokens using a signed permit message
+  /// @param permit The permit data signed over by the owner
+  /// @param owner The owner of the tokens to transfer
+  /// @param transferDetails Specifies the recipient and requested amount for the token transfer
+  /// @param signature The signature to verify
+  function permitTransferFrom(
+    PermitBatchTransferFrom memory permit,
+    SignatureTransferDetails[] calldata transferDetails,
+    address owner,
+    bytes calldata signature
+  ) external;
+
+  /// @notice Transfers multiple tokens using a signed permit message
+  /// @dev The witness type string must follow EIP712 ordering of nested structs and must include the TokenPermissions type definition
+  /// @notice Includes extra data provided by the caller to verify signature over
+  /// @param permit The permit data signed over by the owner
+  /// @param owner The owner of the tokens to transfer
+  /// @param transferDetails Specifies the recipient and requested amount for the token transfer
+  /// @param witness Extra data to include when checking the user signature
+  /// @param witnessTypeString The EIP-712 type definition for remaining string stub of the typehash
+  /// @param signature The signature to verify
+  function permitWitnessTransferFrom(
+    PermitBatchTransferFrom memory permit,
+    SignatureTransferDetails[] calldata transferDetails,
+    address owner,
+    bytes32 witness,
+    string calldata witnessTypeString,
+    bytes calldata signature
+  ) external;
+
+  /// @notice Invalidates the bits specified in mask for the bitmap at the word position
+  /// @dev The wordPos is maxed at type(uint248).max
+  /// @param wordPos A number to index the nonceBitmap at
+  /// @param mask A bitmap masked against msg.sender's current bitmap at the word position
+  function invalidateUnorderedNonces(uint256 wordPos, uint256 mask) external;
+}

--- a/packages/hardhat/contracts/libraries/LibUniV2Router.sol
+++ b/packages/hardhat/contracts/libraries/LibUniV2Router.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.19;
 import {IUniswapV2Pair} from 'contracts/interfaces/external/IUniswapV2Pair.sol';
 import {IUniswapV2Router02} from '@uniswap/v2-periphery/contracts/interfaces/IUniswapV2Router02.sol';
 import {IWETH} from '@uniswap/v2-periphery/contracts/interfaces/IWETH.sol';
+import {IPermit2} from '../interfaces/external/IPermit2.sol';
 
 error InitializationFunctionReverted(address _initializationContractAddress, bytes _calldata);
 
@@ -15,6 +16,7 @@ library LibUniV2Router {
     IWETH weth;
     IUniswapV2Router02 uniswapV2router02;
     address uniswapV2Factory;
+    IPermit2 permit2;
   }
 
   function diamondStorage() internal pure returns (DiamondStorage storage s) {

--- a/packages/hardhat/contracts/libraries/LibWarp.sol
+++ b/packages/hardhat/contracts/libraries/LibWarp.sol
@@ -2,12 +2,14 @@
 pragma solidity 0.8.19;
 
 import {IWETH} from '@uniswap/v2-periphery/contracts/interfaces/IWETH.sol';
+import {IPermit2} from '../interfaces/external/IPermit2.sol';
 
 library LibWarp {
   bytes32 constant DIAMOND_STORAGE_SLOT = keccak256('diamond.storage.LibWarp');
 
   struct State {
     IWETH weth;
+    IPermit2 permit2;
   }
 
   function state() internal pure returns (State storage s) {

--- a/packages/hardhat/contracts/libraries/PermitParams.sol
+++ b/packages/hardhat/contracts/libraries/PermitParams.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+struct PermitParams {
+  uint256 nonce;
+  bytes signature;
+}

--- a/packages/hardhat/contracts/libraries/Stream.sol
+++ b/packages/hardhat/contracts/libraries/Stream.sol
@@ -74,6 +74,24 @@ library Stream {
     }
   }
 
+  function readUint48(uint256 stream) internal pure returns (uint48 res) {
+    assembly {
+      let pos := mload(stream)
+      pos := add(pos, 6)
+      res := mload(pos)
+      mstore(stream, pos)
+    }
+  }
+
+  function readUint160(uint256 stream) internal pure returns (uint160 res) {
+    assembly {
+      let pos := mload(stream)
+      pos := add(pos, 20)
+      res := mload(pos)
+      mstore(stream, pos)
+    }
+  }
+
   function readUint256(uint256 stream) internal pure returns (uint256 res) {
     assembly {
       let pos := mload(stream)

--- a/packages/hardhat/deploy/003_facets.ts
+++ b/packages/hardhat/deploy/003_facets.ts
@@ -62,6 +62,7 @@ const func = async function (hre: HardhatRuntimeEnvironment) {
         calldata: initContract.interface.encodeFunctionData('init', [
           addresses.uniswapV2Router02,
           addresses.uniswapV2Factory,
+          addresses.permit2,
         ]),
       };
     },

--- a/packages/hardhat/deploy/003_facets.ts
+++ b/packages/hardhat/deploy/003_facets.ts
@@ -81,7 +81,10 @@ const func = async function (hre: HardhatRuntimeEnvironment) {
 
       return {
         address: initDeployment.address,
-        calldata: initContract.interface.encodeFunctionData('init', [addresses.weth]),
+        calldata: initContract.interface.encodeFunctionData('init', [
+          addresses.weth,
+          addresses.permit2,
+        ]),
       };
     },
   };

--- a/packages/hardhat/deploy/addresses.ts
+++ b/packages/hardhat/deploy/addresses.ts
@@ -1,23 +1,28 @@
-type AddressKey = 'uniswapV2Router02' | 'uniswapV2Factory' | 'weth';
+type AddressKey = 'uniswapV2Router02' | 'uniswapV2Factory' | 'weth' | 'permit2';
 
 export const networkAddresses: Partial<Record<string, Partial<Record<AddressKey, string>>>> = {
   mainnet: {
     uniswapV2Router02: '0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D',
     uniswapV2Factory: '0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f',
     weth: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+    permit2: '0x000000000022D473030F116dDEE9F6B43aC78BA3',
   },
   sepolia: {
     uniswapV2Router02: '0xC532a74256D3Db42D0Bf7a0400fEFDbad7694008',
     uniswapV2Factory: '0x7E0987E5b3a30e3f2828572Bb659A548460a3003',
     weth: '0x7b79995e5f793A07Bc00c21412e50Ecae098E7f9',
+    permit2: '0x000000000022D473030F116dDEE9F6B43aC78BA3',
   },
   polygon: {
     weth: '0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270',
+    permit2: '0x000000000022D473030F116dDEE9F6B43aC78BA3',
   },
   arbitrum: {
     weth: '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1',
+    permit2: '0x000000000022D473030F116dDEE9F6B43aC78BA3',
   },
   optimism: {
     weth: '0x4200000000000000000000000000000000000006',
+    permit2: '0x000000000022D473030F116dDEE9F6B43aC78BA3',
   },
 };

--- a/packages/hardhat/test/foundry/helpers/FacetTest.sol
+++ b/packages/hardhat/test/foundry/helpers/FacetTest.sol
@@ -19,9 +19,6 @@ abstract contract FacetTest is DiamondHelpers {
   }
 
   function setUpOn(uint256 chainId, uint256 blockNumber) internal virtual {
-    console2.log('Setting up VM on %s (%s)', chainId, blockNumber);
-    console2.log('RPC URL: %s', StdChains.getChain(chainId).rpcUrl);
-
     vm.createSelectFork(StdChains.getChain(chainId).rpcUrl, blockNumber);
 
     diamond = new SifiDiamond(address(this), address(new DiamondCutFacet()));

--- a/packages/hardhat/test/foundry/helpers/Networks.sol
+++ b/packages/hardhat/test/foundry/helpers/Networks.sol
@@ -1,4 +1,5 @@
 import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import {IPermit2} from '../../../contracts/interfaces/external/IPermit2.sol';
 
 library Mainnet {
   uint256 public constant CHAIN_ID = 1;
@@ -39,6 +40,8 @@ library Optimism {
 }
 
 library Addresses {
+  IPermit2 public constant PERMIT2 = IPermit2(0x000000000022D473030F116dDEE9F6B43aC78BA3);
+
   function weth(uint256 chainId) internal pure returns (IERC20) {
     if (chainId == Mainnet.CHAIN_ID) {
       return Mainnet.WETH;

--- a/packages/hardhat/test/foundry/helpers/PermitSignature.sol
+++ b/packages/hardhat/test/foundry/helpers/PermitSignature.sol
@@ -1,0 +1,384 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import {Vm} from 'forge-std/Vm.sol';
+import 'forge-std/console.sol';
+import {EIP712} from '@openzeppelin/contracts/utils/cryptography/draft-EIP712.sol';
+import {ECDSA} from '@openzeppelin/contracts/utils/cryptography/ECDSA.sol';
+import {IAllowanceTransfer} from 'contracts/interfaces/external/IAllowanceTransfer.sol';
+import {ISignatureTransfer} from 'contracts/interfaces/external/ISignatureTransfer.sol';
+
+contract PermitSignature {
+  Vm private constant vm = Vm(address(uint160(uint256(keccak256('hevm cheat code')))));
+
+  using ECDSA for bytes32;
+
+  bytes32 public constant _PERMIT_DETAILS_TYPEHASH =
+    keccak256('PermitDetails(address token,uint160 amount,uint48 expiration,uint48 nonce)');
+
+  bytes32 public constant _PERMIT_SINGLE_TYPEHASH =
+    keccak256(
+      'PermitSingle(PermitDetails details,address spender,uint256 sigDeadline)PermitDetails(address token,uint160 amount,uint48 expiration,uint48 nonce)'
+    );
+
+  bytes32 public constant _PERMIT_BATCH_TYPEHASH =
+    keccak256(
+      'PermitBatch(PermitDetails[] details,address spender,uint256 sigDeadline)PermitDetails(address token,uint160 amount,uint48 expiration,uint48 nonce)'
+    );
+
+  bytes32 public constant _TOKEN_PERMISSIONS_TYPEHASH =
+    keccak256('TokenPermissions(address token,uint256 amount)');
+
+  bytes32 public constant _PERMIT_TRANSFER_FROM_TYPEHASH =
+    keccak256(
+      'PermitTransferFrom(TokenPermissions permitted,address spender,uint256 nonce,uint256 deadline)TokenPermissions(address token,uint256 amount)'
+    );
+
+  bytes32 public constant _PERMIT_BATCH_TRANSFER_FROM_TYPEHASH =
+    keccak256(
+      'PermitBatchTransferFrom(TokenPermissions[] permitted,address spender,uint256 nonce,uint256 deadline)TokenPermissions(address token,uint256 amount)'
+    );
+
+  function getPermitSignatureRaw(
+    IAllowanceTransfer.PermitSingle memory permit,
+    uint256 privateKey,
+    bytes32 domainSeparator
+  ) internal pure returns (uint8 v, bytes32 r, bytes32 s) {
+    bytes32 permitHash = keccak256(abi.encode(_PERMIT_DETAILS_TYPEHASH, permit.details));
+
+    bytes32 msgHash = keccak256(
+      abi.encodePacked(
+        '\x19\x01',
+        domainSeparator,
+        keccak256(
+          abi.encode(_PERMIT_SINGLE_TYPEHASH, permitHash, permit.spender, permit.sigDeadline)
+        )
+      )
+    );
+
+    (v, r, s) = vm.sign(privateKey, msgHash);
+  }
+
+  function getPermitSignature(
+    IAllowanceTransfer.PermitSingle memory permit,
+    uint256 privateKey,
+    bytes32 domainSeparator
+  ) internal pure returns (bytes memory sig) {
+    (uint8 v, bytes32 r, bytes32 s) = getPermitSignatureRaw(permit, privateKey, domainSeparator);
+    return bytes.concat(r, s, bytes1(v));
+  }
+
+  function getCompactPermitSignature(
+    IAllowanceTransfer.PermitSingle memory permit,
+    uint256 privateKey,
+    bytes32 domainSeparator
+  ) internal pure returns (bytes memory sig) {
+    (uint8 v, bytes32 r, bytes32 s) = getPermitSignatureRaw(permit, privateKey, domainSeparator);
+    bytes32 vs;
+    (r, vs) = _getCompactSignature(v, r, s);
+    return bytes.concat(r, vs);
+  }
+
+  function getCompactPermitTransferSignature(
+    ISignatureTransfer.PermitTransferFrom memory permit,
+    uint256 privateKey,
+    bytes32 domainSeparator
+  ) internal view returns (bytes memory sig) {
+    bytes32 tokenPermissions = keccak256(abi.encode(_TOKEN_PERMISSIONS_TYPEHASH, permit.permitted));
+    bytes32 msgHash = keccak256(
+      abi.encodePacked(
+        '\x19\x01',
+        domainSeparator,
+        keccak256(
+          abi.encode(
+            _PERMIT_TRANSFER_FROM_TYPEHASH,
+            tokenPermissions,
+            address(this),
+            permit.nonce,
+            permit.deadline
+          )
+        )
+      )
+    );
+
+    (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, msgHash);
+    bytes32 vs;
+    (r, vs) = _getCompactSignature(v, r, s);
+    return bytes.concat(r, vs);
+  }
+
+  function _getCompactSignature(
+    uint8 vRaw,
+    bytes32 rRaw,
+    bytes32 sRaw
+  ) internal pure returns (bytes32 r, bytes32 vs) {
+    uint8 v = vRaw - 27; // 27 is 0, 28 is 1
+    vs = bytes32(uint256(v) << 255) | sRaw;
+    return (rRaw, vs);
+  }
+
+  function getPermitBatchSignature(
+    IAllowanceTransfer.PermitBatch memory permit,
+    uint256 privateKey,
+    bytes32 domainSeparator
+  ) internal pure returns (bytes memory sig) {
+    bytes32[] memory permitHashes = new bytes32[](permit.details.length);
+    for (uint256 i = 0; i < permit.details.length; ++i) {
+      permitHashes[i] = keccak256(abi.encode(_PERMIT_DETAILS_TYPEHASH, permit.details[i]));
+    }
+    bytes32 msgHash = keccak256(
+      abi.encodePacked(
+        '\x19\x01',
+        domainSeparator,
+        keccak256(
+          abi.encode(
+            _PERMIT_BATCH_TYPEHASH,
+            keccak256(abi.encodePacked(permitHashes)),
+            permit.spender,
+            permit.sigDeadline
+          )
+        )
+      )
+    );
+
+    (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, msgHash);
+    return bytes.concat(r, s, bytes1(v));
+  }
+
+  function getPermitTransferSignature(
+    ISignatureTransfer.PermitTransferFrom memory permit,
+    uint256 privateKey,
+    bytes32 domainSeparator
+  ) internal view returns (bytes memory sig) {
+    bytes32 tokenPermissions = keccak256(abi.encode(_TOKEN_PERMISSIONS_TYPEHASH, permit.permitted));
+    bytes32 msgHash = keccak256(
+      abi.encodePacked(
+        '\x19\x01',
+        domainSeparator,
+        keccak256(
+          abi.encode(
+            _PERMIT_TRANSFER_FROM_TYPEHASH,
+            tokenPermissions,
+            address(this),
+            permit.nonce,
+            permit.deadline
+          )
+        )
+      )
+    );
+
+    (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, msgHash);
+
+    return bytes.concat(r, s, bytes1(v));
+  }
+
+  // NOTE: This contract comes from https://github.com/Uniswap/permit2/blob/main/test/utils/PermitSignature.sol
+  // but was modified to expect a spender address instead of the default address(this) (see above function)
+  function getPermitTransferToSpenderSignature(
+    ISignatureTransfer.PermitTransferFrom memory permit,
+    uint256 privateKey,
+    bytes32 domainSeparator,
+    address spender
+  ) internal pure returns (bytes memory sig) {
+    bytes32 tokenPermissions = keccak256(abi.encode(_TOKEN_PERMISSIONS_TYPEHASH, permit.permitted));
+    bytes32 msgHash = keccak256(
+      abi.encodePacked(
+        '\x19\x01',
+        domainSeparator,
+        keccak256(
+          abi.encode(
+            _PERMIT_TRANSFER_FROM_TYPEHASH,
+            tokenPermissions,
+            spender,
+            permit.nonce,
+            permit.deadline
+          )
+        )
+      )
+    );
+
+    (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, msgHash);
+
+    return bytes.concat(r, s, bytes1(v));
+  }
+
+  function getPermitWitnessTransferSignature(
+    ISignatureTransfer.PermitTransferFrom memory permit,
+    uint256 privateKey,
+    bytes32 typehash,
+    bytes32 witness,
+    bytes32 domainSeparator
+  ) internal view returns (bytes memory sig) {
+    bytes32 tokenPermissions = keccak256(abi.encode(_TOKEN_PERMISSIONS_TYPEHASH, permit.permitted));
+
+    bytes32 msgHash = keccak256(
+      abi.encodePacked(
+        '\x19\x01',
+        domainSeparator,
+        keccak256(
+          abi.encode(
+            typehash,
+            tokenPermissions,
+            address(this),
+            permit.nonce,
+            permit.deadline,
+            witness
+          )
+        )
+      )
+    );
+
+    (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, msgHash);
+    return bytes.concat(r, s, bytes1(v));
+  }
+
+  function getPermitBatchTransferSignature(
+    ISignatureTransfer.PermitBatchTransferFrom memory permit,
+    uint256 privateKey,
+    bytes32 domainSeparator
+  ) internal view returns (bytes memory sig) {
+    bytes32[] memory tokenPermissions = new bytes32[](permit.permitted.length);
+    for (uint256 i = 0; i < permit.permitted.length; ++i) {
+      tokenPermissions[i] = keccak256(abi.encode(_TOKEN_PERMISSIONS_TYPEHASH, permit.permitted[i]));
+    }
+    bytes32 msgHash = keccak256(
+      abi.encodePacked(
+        '\x19\x01',
+        domainSeparator,
+        keccak256(
+          abi.encode(
+            _PERMIT_BATCH_TRANSFER_FROM_TYPEHASH,
+            keccak256(abi.encodePacked(tokenPermissions)),
+            address(this),
+            permit.nonce,
+            permit.deadline
+          )
+        )
+      )
+    );
+
+    (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, msgHash);
+    return bytes.concat(r, s, bytes1(v));
+  }
+
+  function getPermitBatchWitnessSignature(
+    ISignatureTransfer.PermitBatchTransferFrom memory permit,
+    uint256 privateKey,
+    bytes32 typeHash,
+    bytes32 witness,
+    bytes32 domainSeparator
+  ) internal view returns (bytes memory sig) {
+    bytes32[] memory tokenPermissions = new bytes32[](permit.permitted.length);
+    for (uint256 i = 0; i < permit.permitted.length; ++i) {
+      tokenPermissions[i] = keccak256(abi.encode(_TOKEN_PERMISSIONS_TYPEHASH, permit.permitted[i]));
+    }
+
+    bytes32 msgHash = keccak256(
+      abi.encodePacked(
+        '\x19\x01',
+        domainSeparator,
+        keccak256(
+          abi.encode(
+            typeHash,
+            keccak256(abi.encodePacked(tokenPermissions)),
+            address(this),
+            permit.nonce,
+            permit.deadline,
+            witness
+          )
+        )
+      )
+    );
+
+    (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, msgHash);
+    return bytes.concat(r, s, bytes1(v));
+  }
+
+  function defaultERC20PermitAllowance(
+    address token0,
+    uint160 amount,
+    uint48 expiration,
+    uint48 nonce
+  ) internal view returns (IAllowanceTransfer.PermitSingle memory) {
+    IAllowanceTransfer.PermitDetails memory details = IAllowanceTransfer.PermitDetails({
+      token: token0,
+      amount: amount,
+      expiration: expiration,
+      nonce: nonce
+    });
+    return
+      IAllowanceTransfer.PermitSingle({
+        details: details,
+        spender: address(this),
+        sigDeadline: block.timestamp + 100
+      });
+  }
+
+  function defaultERC20PermitBatchAllowance(
+    address[] memory tokens,
+    uint160 amount,
+    uint48 expiration,
+    uint48 nonce
+  ) internal view returns (IAllowanceTransfer.PermitBatch memory) {
+    IAllowanceTransfer.PermitDetails[] memory details = new IAllowanceTransfer.PermitDetails[](
+      tokens.length
+    );
+
+    for (uint256 i = 0; i < tokens.length; ++i) {
+      details[i] = IAllowanceTransfer.PermitDetails({
+        token: tokens[i],
+        amount: amount,
+        expiration: expiration,
+        nonce: nonce
+      });
+    }
+
+    return
+      IAllowanceTransfer.PermitBatch({
+        details: details,
+        spender: address(this),
+        sigDeadline: block.timestamp + 100
+      });
+  }
+
+  function defaultERC20PermitTransfer(
+    address token0,
+    uint256 nonce
+  ) internal view returns (ISignatureTransfer.PermitTransferFrom memory) {
+    return
+      ISignatureTransfer.PermitTransferFrom({
+        permitted: ISignatureTransfer.TokenPermissions({token: token0, amount: 10 ** 18}),
+        nonce: nonce,
+        deadline: block.timestamp + 100
+      });
+  }
+
+  function defaultERC20PermitWitnessTransfer(
+    address token0,
+    uint256 nonce
+  ) internal view returns (ISignatureTransfer.PermitTransferFrom memory) {
+    return
+      ISignatureTransfer.PermitTransferFrom({
+        permitted: ISignatureTransfer.TokenPermissions({token: token0, amount: 10 ** 18}),
+        nonce: nonce,
+        deadline: block.timestamp + 100
+      });
+  }
+
+  function defaultERC20PermitMultiple(
+    address[] memory tokens,
+    uint256 nonce
+  ) internal view returns (ISignatureTransfer.PermitBatchTransferFrom memory) {
+    ISignatureTransfer.TokenPermissions[]
+      memory permitted = new ISignatureTransfer.TokenPermissions[](tokens.length);
+    for (uint256 i = 0; i < tokens.length; ++i) {
+      permitted[i] = ISignatureTransfer.TokenPermissions({token: tokens[i], amount: 1 ** 18});
+    }
+    return
+      ISignatureTransfer.PermitBatchTransferFrom({
+        permitted: permitted,
+        nonce: nonce,
+        deadline: block.timestamp + 100
+      });
+  }
+}

--- a/packages/hardhat/test/foundry/helpers/WarpLinkEncoder.sol
+++ b/packages/hardhat/test/foundry/helpers/WarpLinkEncoder.sol
@@ -1,7 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
 import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 import {IWarpLink} from 'contracts/interfaces/IWarpLink.sol';
 import {WarpLink} from 'contracts/facets/WarpLink.sol';
 import {IUniswapV2Factory} from 'contracts/interfaces/external/IUniswapV2Factory.sol';
+import {IAllowanceTransfer} from 'contracts/interfaces/external/IAllowanceTransfer.sol';
 
 contract WarpLinkEncoder {
   IWarpLink public warpLink;


### PR DESCRIPTION
This adds 
- the `Permit2` interface and default address

This replaces
- `IERC20.safeTransferFrom` in all swaps

with
- creation of `IAllowanceTransfer.PermitSingle` and publish together with `signature` to Permit2 contract
- `IAllowanceTransfer.transferFrom`