### PR TITLE
feat(frontend): show toast after approval

### DIFF
--- a/packages/frontend/src/hooks/useApprove.tsx
+++ b/packages/frontend/src/hooks/useApprove.tsx
@@ -1,13 +1,14 @@
 import { useState } from 'react';
+import { showToast } from '@sifi/shared-ui';
 import { useMutation } from '@tanstack/react-query';
 import { erc20ABI, usePublicClient, useWalletClient } from 'wagmi';
 import { useWatch } from 'react-hook-form';
 import { MAX_ALLOWANCE } from 'src/constants';
 import { SwapFormKey } from 'src/providers/SwapFormProvider';
-import { getTokenBySymbol } from 'src/utils';
+import { getEvmTxUrl, getTokenBySymbol } from 'src/utils';
+import { useSelectedChain } from 'src/providers/SelectedChainProvider';
 import { useQuote } from './useQuote';
 import { useTokens } from './useTokens';
-import { useSelectedChain } from 'src/providers/SelectedChainProvider';
 
 const useApprove = () => {
   const { selectedChain } = useSelectedChain();
@@ -52,6 +53,13 @@ const useApprove = () => {
     setIsApprovalModalOpen(false);
 
     await publicClient.waitForTransactionReceipt({ hash });
+    const explorerLink = getEvmTxUrl(selectedChain, hash);
+    showToast({
+      type: 'success',
+      text: `Approved ${fromTokenSymbol} for trading`,
+      link: { href: explorerLink || '', text: 'View Transaction' },
+    });
+    setIsLoading(false);
   };
 
   const mutation = useMutation(['requestApproval'], requestApproval, { retry: 0 });


### PR DESCRIPTION
### Changes Made

- Show a toast after approving a token for trading to inform the user

### Screenshots/videos

https://github.com/sideshiftfi/sifi/assets/128688932/287b0b18-dc2e-4867-b197-b4ef2b30cb0e

### Checklist

Please tick the boxes that apply and provide additional details where necessary. Add or edit items as needed.

- [x] Changes are limited to a single goal.
- [x] Responsive design has been tested and looks good on all devices and screen sizes.
- [x] Changes have been tested on all major browsers (Chrome, Firefox, Safari).
- [x] The changes in Chromatic UI Tests all look good.
- [x] No accessibility issues have been introduced in Storybook's Accessibility tab.
- [x] The code has been optimized for performance.

### Related

Closes #169 
