### PR TITLE
feat(frontend): clear token amount on token or network change

### DIFF
--- a/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
+++ b/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
@@ -132,6 +132,11 @@ const CreateSwap = () => {
   const spendableBalance = useSpendableBalance({ token: fromToken });
   const depositMax = isConnected ? spendableBalance : undefined;
 
+  const resetTokenAmounts = () => {
+    setValue(SwapFormKey.FromAmount, '');
+    setValue(SwapFormKey.ToAmount, '');
+  };
+
   useEffect(() => {
     if (tokens.length > 1) {
       setValue(fromTokenKey, tokens[0].symbol);
@@ -141,10 +146,15 @@ const CreateSwap = () => {
 
   useEffect(() => {
     if (isSameTokenPair) {
-      setValue(SwapFormKey.FromAmount, '');
-      setValue(SwapFormKey.ToAmount, '');
+      resetTokenAmounts();
     }
   }, [isSameTokenPair]);
+
+  useEffect(() => {
+    if (fromToken) {
+      setValue(SwapFormKey.FromAmount, '');
+    }
+  }, [fromToken])
 
   return (
     <div className="m:w-full py-2 sm:max-w-md">


### PR DESCRIPTION
Clears token amounts when the `fromToken` changes - fromToken is also a function of the token list, so this also acts as a reset on network change.

### Screenshots/videos

https://github.com/sideshiftfi/sifi/assets/112887817/9fc942dd-7eea-460c-a5cd-dc1d4fce351e

### Testing

 - Video
   - [X]  A user switching their connected network in the wallet does *not* reset the form
   - [X] User switching target source network in dropdown results in reset
   - [X] User switching fromToken results in reset 

### Checklist

Please tick the boxes that apply and provide additional details where necessary. Add or edit items as needed.

- [X] Changes are limited to a single goal.
- [X] Responsive design has been tested and looks good on all devices and screen sizes.
- [X] Changes have been tested on all major browsers (Chrome, Firefox, Safari).
- [X] The changes in Chromatic UI Tests all look good.
- [X] No accessibility issues have been introduced in Storybook's Accessibility tab.
- [X] The code has been optimized for performance.
