### PR TITLE
feat(frontend): default to user connected network

### DIFF
--- a/packages/frontend/src/AppProvider.tsx
+++ b/packages/frontend/src/AppProvider.tsx
@@ -20,16 +20,16 @@ export const AppProvider: FC<PropsWithChildren> = ({ children }) => {
       <QueryProvider client={queryClient}>
         <AnalyticsProvider>
           <SDKProvider>
+            <WagmiProvider>
             <SelectedChainProvider>
               <TokensProvider>
                 <SwapFormProvider>
-                  <WagmiProvider>
                     {children}
                     <CustomToastContainer />
-                  </WagmiProvider>
                 </SwapFormProvider>
               </TokensProvider>
-            </SelectedChainProvider>
+              </SelectedChainProvider>
+            </WagmiProvider>
           </SDKProvider>
         </AnalyticsProvider>
         <ReactQueryDevtools initialIsOpen={false} />

--- a/packages/frontend/src/providers/SelectedChainProvider.tsx
+++ b/packages/frontend/src/providers/SelectedChainProvider.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useState, useContext } from 'react';
 import { SUPPORTED_CHAINS } from 'src/utils/chains';
 import { Chain } from 'viem';
+import { useNetwork } from 'wagmi';
 
 type SelectedChainContextType = {
   selectedChain: Chain;
@@ -10,7 +11,10 @@ type SelectedChainContextType = {
 const SelectedChainContext = createContext<SelectedChainContextType | undefined>(undefined);
 
 const SelectedChainProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
-  const [selectedChain, setSelectedChain] = useState(SUPPORTED_CHAINS[0]);
+  const { chain: connectedChain } = useNetwork();
+  const defaultChain: Chain = SUPPORTED_CHAINS.find((chain) => chain.id === connectedChain?.id) || SUPPORTED_CHAINS[0];
+
+  const [selectedChain, setSelectedChain] = useState(defaultChain);
 
   return (
     <SelectedChainContext.Provider value={{ selectedChain, setSelectedChain }}>


### PR DESCRIPTION
### Changes Made

 - Sets default network to users network (if available)

### Additional Notes
 
 - Falls back to Ethereum L1 if connected network is not supported

### Screenshots/videos

https://github.com/sideshiftfi/sifi/assets/112887817/4cc69699-3008-4d56-99cd-4ad6dd44e420

### Testing

 - See video

### Checklist

Please tick the boxes that apply and provide additional details where necessary. Add or edit items as needed.

- [X] Changes are limited to a single goal.
- [X] Responsive design has been tested and looks good on all devices and screen sizes.
- [X] Changes have been tested on all major browsers (Chrome, Firefox, Safari).
- [X] The changes in Chromatic UI Tests all look good.
- [X] No accessibility issues have been introduced in Storybook's Accessibility tab.
- [X] The code has been optimized for performance.
