### PR TITLE
feat(hardhat): add stargate jump

### DIFF
--- a/packages/hardhat/.gitignore
+++ b/packages/hardhat/.gitignore
@@ -11,4 +11,5 @@ artifacts
 gas-report.txt
 solidity-files-cache.json
 deployments/sepolia
+deployments/goerli
 results.sarif

--- a/packages/hardhat/contracts/init/InitLibWarp.sol
+++ b/packages/hardhat/contracts/init/InitLibWarp.sol
@@ -4,12 +4,14 @@ pragma solidity ^0.8.19;
 import {IWETH} from '@uniswap/v2-periphery/contracts/interfaces/IWETH.sol';
 import {LibWarp} from '../libraries/LibWarp.sol';
 import {IPermit2} from '../interfaces/external/IPermit2.sol';
+import {IStargateRouter} from '../interfaces/external/IStargateRouter.sol';
 
 contract InitLibWarp {
-  function init(address weth, address permit2) public {
+  function init(address weth, address permit2, address router) public {
     LibWarp.State storage s = LibWarp.state();
 
     s.weth = IWETH(weth);
     s.permit2 = IPermit2(permit2);
+    s.stargateRouter = IStargateRouter(router);
   }
 }

--- a/packages/hardhat/contracts/interfaces/IWarpLink.sol
+++ b/packages/hardhat/contracts/interfaces/IWarpLink.sol
@@ -5,7 +5,7 @@ import {PermitParams} from '../libraries/PermitParams.sol';
 
 interface IWarpLink {
   error UnhandledCommand();
-  error IncorrectEthValue();
+  error InsufficientEthValue();
   error InsufficientOutputAmount();
   error InsufficientTokensDelivered();
   error UnexpectedTokenForWrap();
@@ -15,10 +15,11 @@ interface IWarpLink {
   error NotEnoughParts();
   error InconsistentPartTokenOut();
   error InconsistentPartPayerOut();
-  error UnexpectedValueAndTokenCombination();
   error UnexpectedPayerForWrap();
-  error EthNotSupportedForWarp();
+  error NativeTokenNotSupported();
   error DeadlineExpired();
+  error IllegalJumpInSplit();
+  error JumpMustBeLastCommand();
 
   struct Params {
     address partner;

--- a/packages/hardhat/contracts/interfaces/external/IStargateRouter.sol
+++ b/packages/hardhat/contracts/interfaces/external/IStargateRouter.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+pragma solidity >=0.7.6;
+pragma abicoder v2;
+
+interface IStargateRouter {
+  struct lzTxObj {
+    uint256 dstGasForCall;
+    uint256 dstNativeAmount;
+    bytes dstNativeAddr;
+  }
+
+  function swap(
+    uint16 _dstChainId,
+    uint256 _srcPoolId,
+    uint256 _dstPoolId,
+    address payable _refundAddress,
+    uint256 _amountLD,
+    uint256 _minAmountLD,
+    lzTxObj memory _lzTxParams,
+    bytes calldata _to,
+    bytes calldata _payload
+  ) external payable;
+}

--- a/packages/hardhat/contracts/libraries/LibWarp.sol
+++ b/packages/hardhat/contracts/libraries/LibWarp.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.19;
 
 import {IWETH} from '@uniswap/v2-periphery/contracts/interfaces/IWETH.sol';
 import {IPermit2} from '../interfaces/external/IPermit2.sol';
+import {IStargateRouter} from '../interfaces/external/IStargateRouter.sol';
 
 library LibWarp {
   bytes32 constant DIAMOND_STORAGE_SLOT = keccak256('diamond.storage.LibWarp');
@@ -10,6 +11,7 @@ library LibWarp {
   struct State {
     IWETH weth;
     IPermit2 permit2;
+    IStargateRouter stargateRouter;
   }
 
   function state() internal pure returns (State storage s) {

--- a/packages/hardhat/deploy-helpers/addresses.ts
+++ b/packages/hardhat/deploy-helpers/addresses.ts
@@ -1,4 +1,4 @@
-type AddressKey = 'uniswapV2Router02' | 'uniswapV2Factory' | 'weth' | 'permit2';
+type AddressKey = 'uniswapV2Router02' | 'uniswapV2Factory' | 'weth' | 'permit2' | 'stargateRouter';
 
 export const networkAddresses: Partial<Record<string, Partial<Record<AddressKey, string>>>> = {
   mainnet: {
@@ -6,12 +6,14 @@ export const networkAddresses: Partial<Record<string, Partial<Record<AddressKey,
     uniswapV2Factory: '0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f',
     weth: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
     permit2: '0x000000000022D473030F116dDEE9F6B43aC78BA3',
+    stargateRouter: '0x8731d54E9D02c286767d56ac03e8037C07e01e98',
   },
   goerli: {
     uniswapV2Router02: '0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D',
     uniswapV2Factory: '0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f',
     weth: '0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6',
     permit2: '0x000000000022D473030F116dDEE9F6B43aC78BA3',
+    stargateRouter: '0x7612aE2a34E5A363E137De748801FB4c86499152',
   },
   sepolia: {
     uniswapV2Router02: '0xC532a74256D3Db42D0Bf7a0400fEFDbad7694008',
@@ -22,13 +24,16 @@ export const networkAddresses: Partial<Record<string, Partial<Record<AddressKey,
   polygon: {
     weth: '0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270',
     permit2: '0x000000000022D473030F116dDEE9F6B43aC78BA3',
+    stargateRouter: '0x45A01E4e04F14f7A4a6702c74187c5F6222033cd',
   },
   arbitrum: {
     weth: '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1',
     permit2: '0x000000000022D473030F116dDEE9F6B43aC78BA3',
+    stargateRouter: '0x53Bf833A5d6c4ddA888F69c22C88C9f356a41614',
   },
   optimism: {
     weth: '0x4200000000000000000000000000000000000006',
     permit2: '0x000000000022D473030F116dDEE9F6B43aC78BA3',
+    stargateRouter: '0x53Bf833A5d6c4ddA888F69c22C88C9f356a41614',
   },
 };

--- a/packages/hardhat/deploy-helpers/addresses.ts
+++ b/packages/hardhat/deploy-helpers/addresses.ts
@@ -7,6 +7,12 @@ export const networkAddresses: Partial<Record<string, Partial<Record<AddressKey,
     weth: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
     permit2: '0x000000000022D473030F116dDEE9F6B43aC78BA3',
   },
+  goerli: {
+    uniswapV2Router02: '0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D',
+    uniswapV2Factory: '0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f',
+    weth: '0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6',
+    permit2: '0x000000000022D473030F116dDEE9F6B43aC78BA3',
+  },
   sepolia: {
     uniswapV2Router02: '0xC532a74256D3Db42D0Bf7a0400fEFDbad7694008',
     uniswapV2Factory: '0x7E0987E5b3a30e3f2828572Bb659A548460a3003',

--- a/packages/hardhat/deploy/003_facets.ts
+++ b/packages/hardhat/deploy/003_facets.ts
@@ -257,10 +257,12 @@ const func = async function (hre: HardhatRuntimeEnvironment) {
 
   console.log('Cuts:');
 
-  // HACK: Do not replace the OwnershipFacet for Polygon. It's always proposed as a replacement,
-  // but fails with the error that it's being replaced with itself
-  if (network.name === 'polygon') {
-    cuts = cuts.filter(cut => cut.facetName !== 'OwnershipFacet');
+  // HACK: Some replacements are always proposed, but fail with the error that it's being
+  // replaced with the same selector
+  if (network.name === 'polygon' || network.name === 'goerli') {
+    cuts = cuts.filter(
+      cut => cut.facetName !== 'OwnershipFacet' && cut.facetName !== 'DiamondLoupeFacet'
+    );
   }
 
   for (const cut of cuts) {

--- a/packages/hardhat/deploy/003_facets.ts
+++ b/packages/hardhat/deploy/003_facets.ts
@@ -84,6 +84,7 @@ const func = async function (hre: HardhatRuntimeEnvironment) {
         calldata: initContract.interface.encodeFunctionData('init', [
           addresses.weth,
           addresses.permit2,
+          addresses.stargateRouter ?? '0x0000000000000000000000000000000000000000',
         ]),
       };
     },

--- a/packages/hardhat/hardhat.config.ts
+++ b/packages/hardhat/hardhat.config.ts
@@ -64,6 +64,12 @@ const config = {
       accounts: { mnemonic: '' },
     },
     hardhat: {},
+    goerli: {
+      url: getNetworkUrl('goerli'),
+      accounts: { mnemonic: '' },
+      chainId: 5,
+      gasMultiplier: 2,
+    },
     sepolia: {
       url: getNetworkUrl('sepolia'),
       accounts: { mnemonic: '' },
@@ -91,6 +97,7 @@ if (ETHERSCAN_API_KEY) {
   config.etherscan = {
     apiKey: {
       mainnet: ETHERSCAN_API_KEY,
+      goerli: ETHERSCAN_API_KEY,
       sepolia: ETHERSCAN_API_KEY,
       polygon: POLYGON_SCAN_API_KEY,
       arbitrumOne: ARBITRUM_SCAN_API_KEY,
@@ -122,6 +129,13 @@ if (EVM_MNEMONIC) {
 if (DEV_MNEMONIC) {
   config.networks.hardhat = {
     ...config.networks.hardhat,
+    accounts: {
+      mnemonic: DEV_MNEMONIC,
+    },
+  };
+
+  config.networks.goerli = {
+    ...config.networks.goerli,
     accounts: {
       mnemonic: DEV_MNEMONIC,
     },

--- a/packages/hardhat/helper-hardhat-config.ts
+++ b/packages/hardhat/helper-hardhat-config.ts
@@ -18,6 +18,10 @@ export const NETWORK_CONFIGS: Partial<Record<string, NetworkConfig>> = {
     uniV2RouterAddress: '0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D', // wrong but ok for deployment testing
     blockConfirmations: 1,
   },
+  goerli: {
+    isDev: true,
+    blockConfirmations: 6,
+  },
   sepolia: {
     isDev: true,
     wethAddress: '0x7b79995e5f793A07Bc00c21412e50Ecae098E7f9',

--- a/packages/hardhat/test/foundry/Curve.t.sol
+++ b/packages/hardhat/test/foundry/Curve.t.sol
@@ -50,7 +50,12 @@ contract CurveTest is FacetTest, PermitSignature {
     IDiamondCut(address(diamond)).diamondCut(
       facetCuts,
       address(new InitLibWarp()),
-      abi.encodeWithSelector(InitLibWarp.init.selector, Addresses.weth(1), Addresses.PERMIT2)
+      abi.encodeWithSelector(
+        InitLibWarp.init.selector,
+        Addresses.weth(1),
+        Addresses.PERMIT2,
+        Addresses.stargateRouter(1)
+      )
     );
 
     facet = ICurve(address(diamond));

--- a/packages/hardhat/test/foundry/UniV2LikeFacet.t.sol
+++ b/packages/hardhat/test/foundry/UniV2LikeFacet.t.sol
@@ -52,7 +52,12 @@ contract UniV2LikeFacetTestBase is FacetTest, PermitSignature {
     IDiamondCut(address(diamond)).diamondCut(
       facetCuts,
       address(new InitLibWarp()),
-      abi.encodeWithSelector(InitLibWarp.init.selector, Addresses.weth(chainId), Addresses.PERMIT2)
+      abi.encodeWithSelector(
+        InitLibWarp.init.selector,
+        Addresses.weth(chainId),
+        Addresses.PERMIT2,
+        Addresses.stargateRouter(chainId)
+      )
     );
 
     facet = IUniV2Like(address(diamond));

--- a/packages/hardhat/test/foundry/UniV3Like.t.sol
+++ b/packages/hardhat/test/foundry/UniV3Like.t.sol
@@ -53,7 +53,12 @@ abstract contract UniV3LikeTestBase is FacetTest, PermitSignature {
     IDiamondCut(address(diamond)).diamondCut(
       facetCuts,
       address(new InitLibWarp()),
-      abi.encodeWithSelector(InitLibWarp.init.selector, Addresses.weth(chainId), Addresses.PERMIT2)
+      abi.encodeWithSelector(
+        InitLibWarp.init.selector,
+        Addresses.weth(chainId),
+        Addresses.PERMIT2,
+        Addresses.stargateRouter(chainId)
+      )
     );
 
     facet = IUniV3Like(address(diamond));

--- a/packages/hardhat/test/foundry/helpers/Networks.sol
+++ b/packages/hardhat/test/foundry/helpers/Networks.sol
@@ -17,12 +17,14 @@ library Mainnet {
   address public constant UNISWAP_V2_FACTORY_ADDR = 0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f;
   address public constant SUSHISWAP_V2_FACTORY = 0xC0AEe478e3658e2610c5F7A4A2E1777cE9e4f2Ac;
   address public constant PANCAKESWAP_V2_FACTORY = 0x1097053Fd2ea711dad45caCcc45EfF7548fCB362;
+  address public constant STARGATE_ROUTER_ADDR = 0x8731d54E9D02c286767d56ac03e8037C07e01e98;
 }
 
 library Arbitrum {
   uint256 public constant CHAIN_ID = 42161;
   IERC20 public constant WETH = IERC20(0x82aF49447D8a07e3bd95BD0d56f35241523fBab1);
   IERC20 public constant USDC = IERC20(0xaf88d065e77c8cC2239327C5EDb3A432268e5831);
+  address public constant STARGATE_ROUTER_ADDR = 0x53Bf833A5d6c4ddA888F69c22C88C9f356a41614;
 }
 
 library Polygon {
@@ -30,6 +32,7 @@ library Polygon {
   IERC20 public constant WMATIC = IERC20(0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270);
   IERC20 public constant USDC = IERC20(0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174);
   IERC20 public constant USDT = IERC20(0xc2132D05D31c914a87C6611C10748AEb04B58e8F);
+  address public constant STARGATE_ROUTER_ADDR = 0x45A01E4e04F14f7A4a6702c74187c5F6222033cd;
 }
 
 library Optimism {
@@ -37,6 +40,17 @@ library Optimism {
   IERC20 public constant WETH = IERC20(0x4200000000000000000000000000000000000006);
   IERC20 public constant USDC = IERC20(0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85);
   IERC20 public constant USDT = IERC20(0x94b008aA00579c1307B0EF2c499aD98a8ce58e58);
+  address public constant STARGATE_ROUTER_ADDR = 0x53Bf833A5d6c4ddA888F69c22C88C9f356a41614;
+}
+
+library Avalanche {
+  uint256 public constant CHAIN_ID = 43114;
+  address public constant STARGATE_ROUTER_ADDR = 0x45A01E4e04F14f7A4a6702c74187c5F6222033cd;
+}
+
+library Goerli {
+  uint256 public constant CHAIN_ID = 5;
+  address public constant STARGATE_ROUTER_ADDR = 0x7612aE2a34E5A363E137De748801FB4c86499152;
 }
 
 library Addresses {
@@ -52,7 +66,25 @@ library Addresses {
     } else if (chainId == Optimism.CHAIN_ID) {
       return Optimism.WETH;
     } else {
-      revert('Unsupported chain');
+      return IERC20(address(0));
+    }
+  }
+
+  function stargateRouter(uint256 chainId) internal pure returns (address) {
+    if (chainId == Mainnet.CHAIN_ID) {
+      return Mainnet.STARGATE_ROUTER_ADDR;
+    } else if (chainId == Optimism.CHAIN_ID) {
+      return Optimism.STARGATE_ROUTER_ADDR;
+    } else if (chainId == Avalanche.CHAIN_ID) {
+      return Avalanche.STARGATE_ROUTER_ADDR;
+    } else if (chainId == Goerli.CHAIN_ID) {
+      return Goerli.STARGATE_ROUTER_ADDR;
+    } else if (chainId == Polygon.CHAIN_ID) {
+      return Polygon.STARGATE_ROUTER_ADDR;
+    } else if (chainId == Arbitrum.CHAIN_ID) {
+      return Arbitrum.STARGATE_ROUTER_ADDR;
+    } else {
+      return address(0);
     }
   }
 }


### PR DESCRIPTION
This PR adds support for the first jump (bridge), Stargate

## Notes

Note that the LayerZero cross-chain messaging fee is paid in the native token

## Changes

- feat(hardhat): add goerli testnet
- feat(hardhat): add stargate jump

## Gas

Gas usage is up, likely from extra checks and fields added to the transient storage

```
testFork_deadline() (gas: 0 (0.000%)) 
testFork_warpCurveDaiToGusd() (gas: 531 (0.092%)) 
testFork_univ3LikeMulti() (gas: 515 (0.099%)) 
testFork_swapSingleUniV3() (gas: 499 (0.112%)) 
testFork_univ2LikeMulti() (gas: 516 (0.123%)) 
testFork_collectFee() (gas: 529 (0.129%)) 
testFork_swapSingleUniV2Sushi() (gas: 529 (0.166%)) 
testFork_positiveSlippage() (gas: 529 (0.169%)) 
testFork_Unwrap() (gas: 518 (0.189%)) 
testFork_warpCurveV1AndFactory() (gas: 868 (0.189%)) 
testFork_swapSingleUniV3() (gas: 885 (0.218%)) 
testFork_swapSingleUniV3() (gas: 885 (0.339%)) 
testFork_swapSingleUniV3() (gas: 885 (0.363%)) 
testFork_paraswapVector() (gas: 2887 (0.387%)) 
testFork_Wrap() (gas: 717 (0.882%)) 
testFork_Wrap() (gas: 717 (0.885%)) 
testFork_Wrap() (gas: 717 (0.890%)) 
testFork_splitWrap() (gas: 2322 (2.180%)) 
testFork_warpCurveV2Twice() (gas: 0 (NaN%)) 
testFork_warpCurve_EthToSteth() (gas: 693 (0.203%)) 
testFork_warpCurve_StethToEth() (gas: 664 (0.219%)) 
testFork_wrapAndSwapSingleUniV2Chained() (gas: 874 (0.366%)) 
testFork_wrapAndSwapSingleUniV2Sushi() (gas: 903 (0.572%)) 
testFork_Wrap() (gas: 717 (0.756%)) 
testFork_wrapSplitSwapNested() (gas: 3240 (0.869%)) 
testFork_wrapSplitSwap() (gas: 1962 (0.882%)) 
```

## Testing

- [x] Used WarpLink to jump 1 USDC (mock) from Goerli to Optimism-Goerli
