### PR TITLE
tooling(frontend): add package.json script to use local backend

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -11,6 +11,7 @@
     "build": "tsc && vite build",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "dev": "vite",
+    "dev:local": "REACT_APP_BACKEND_OVERRIDE=localhost vite",
     "lint": "eslint \"./src/**/*.{js,jsx,ts,tsx}\" || true",
     "preview": "vite preview",
     "storybook": "env STORYBOOK_DEV=true storybook dev -p 6006",

--- a/packages/frontend/src/providers/SDKProvider.tsx
+++ b/packages/frontend/src/providers/SDKProvider.tsx
@@ -1,9 +1,10 @@
 import { Sifi } from '@sifi/sdk';
 import { createContext, useContext, useMemo } from 'react';
+import { baseUrl } from 'src/utils';
 
 let sifi: Sifi;
 
-const SDKContext = createContext<Sifi>(new Sifi());
+const SDKContext = createContext<Sifi>(new Sifi(baseUrl));
 
 const useSifi = (): Sifi => useContext(SDKContext);
 
@@ -11,7 +12,7 @@ const SDKProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
   // TODO: Add error handling
   const value = useMemo(() => {
     if (!sifi) {
-      sifi = new Sifi();
+      sifi = new Sifi(baseUrl);
     }
 
     return sifi;

--- a/packages/frontend/src/utils/api.ts
+++ b/packages/frontend/src/utils/api.ts
@@ -1,3 +1,3 @@
-const baseUrl = 'https://api.sideshift.fi';
+const baseUrl = import.meta.env.REACT_APP_BACKEND_OVERRIDE === 'localhost' ? 'http://localhost:3100/v1/' : 'https://api.sideshift.fi/v1/';
 
 export { baseUrl };


### PR DESCRIPTION
 - Adds `pnpm dev:local` to frontend package, allowing us to easily connect to a local backend when required for testing.


### Testing
 - [X] Normally, the live api is still used
 - [X] `pnpm dev:local` uses local backend for quote fetching