### PR TITLE
chore(frontend): upgrade @sifi/shared-ui to 1.7.5

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -22,7 +22,7 @@
     "@headlessui/react": "^1.7.4",
     "@heroicons/react": "^2.0.12",
     "@sifi/sdk": "^1.8.0",
-    "@sifi/shared-ui": "^1.7.4",
+    "@sifi/shared-ui": "^1.7.5",
     "@tanstack/react-query": "^4.13.0",
     "@uniswap/permit2-sdk": "^1.2.0",
     "@wagmi/core": "^1.3.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,8 +57,8 @@ importers:
         specifier: ^1.8.0
         version: link:../sdk
       '@sifi/shared-ui':
-        specifier: ^1.7.4
-        version: 1.7.4(@headlessui/react@1.7.11)(date-fns@2.29.3)(react-dom@18.2.0)(react-hook-form@7.43.1)(react-router-dom@6.0.1)(react@18.2.0)(viem@1.9.0)(wagmi@1.3.10)
+        specifier: ^1.7.5
+        version: 1.7.5(@headlessui/react@1.7.11)(date-fns@2.29.3)(react-dom@18.2.0)(react-hook-form@7.43.1)(react-router-dom@6.0.1)(react@18.2.0)(viem@1.9.0)(wagmi@1.3.10)
       '@tanstack/react-query':
         specifier: ^4.13.0
         version: 4.28.0(react-dom@18.2.0)(react@18.2.0)
@@ -261,6 +261,10 @@ importers:
       solhint-plugin-prettier:
         specifier: ^0.0.5
         version: 0.0.5(prettier-plugin-solidity@1.1.3)(prettier@2.8.8)
+
+  packages/hardhat/lib/forge-std: {}
+
+  packages/hardhat/lib/forge-std/lib/ds-test: {}
 
   packages/sdk:
     devDependencies:
@@ -5544,8 +5548,8 @@ packages:
       tslib: 1.14.1
     dev: true
 
-  /@sifi/shared-ui@1.7.4(@headlessui/react@1.7.11)(date-fns@2.29.3)(react-dom@18.2.0)(react-hook-form@7.43.1)(react-router-dom@6.0.1)(react@18.2.0)(viem@1.9.0)(wagmi@1.3.10):
-    resolution: {integrity: sha512-oNKZ0E5JCRklw4PvMaKsnWPNpkuL4Jfs99nPJNnJU4iGeUadEcsgzSauxXYxFf8+NxtXg3EghObRi2UYROsTNQ==}
+  /@sifi/shared-ui@1.7.5(@headlessui/react@1.7.11)(date-fns@2.29.3)(react-dom@18.2.0)(react-hook-form@7.43.1)(react-router-dom@6.0.1)(react@18.2.0)(viem@1.9.0)(wagmi@1.3.10):
+    resolution: {integrity: sha512-+aZCcKtY0LyQnYJ56bCNHW9LxD6rm6drpf7OMvYSl+lkvcNv7s/yNRNombT4tz+rLW+Qgiv2xbK+uI8CWSRHsQ==}
     peerDependencies:
       '@headlessui/react': ^1.7.3
       date-fns: 2.29.3


### PR DESCRIPTION
Upgrades shared-ui to 1.7.5, which is supposed to bring up the coins with balances to the top in `TokenSelector`. 