### PR TITLE
feat(hardhat): support post-jump commands for Stargate

### DIFF
--- a/packages/hardhat/.gitignore
+++ b/packages/hardhat/.gitignore
@@ -7,6 +7,7 @@ typechain-types
 
 # Hardhat files
 cache
+cache_forge/
 artifacts
 gas-report.txt
 solidity-files-cache.json
@@ -14,3 +15,4 @@ deployments/sepolia
 deployments/goerli
 deployments/optimismGoerli
 results.sarif
+broadcast/

--- a/packages/hardhat/.gitignore
+++ b/packages/hardhat/.gitignore
@@ -12,4 +12,5 @@ gas-report.txt
 solidity-files-cache.json
 deployments/sepolia
 deployments/goerli
+deployments/optimismGoerli
 results.sarif

--- a/packages/hardhat/contracts/facets/WarpLink.sol
+++ b/packages/hardhat/contracts/facets/WarpLink.sol
@@ -79,7 +79,6 @@ contract WarpLink is IWarpLink, WarpLinkCommandTypes {
     uint256 amount;
     address payer;
     address token;
-    uint48 deadline;
     /**
      * 0 or 1
      */
@@ -781,7 +780,6 @@ contract WarpLink is IWarpLink, WarpLinkCommandTypes {
     t.paramSlippageBps = params.slippageBps;
     t.amount = params.amountIn;
     t.token = params.tokenIn;
-    t.deadline = params.deadline;
 
     if (params.tokenIn == address(0)) {
       if (msg.value < params.amountIn) {

--- a/packages/hardhat/contracts/interfaces/IWarpLink.sol
+++ b/packages/hardhat/contracts/interfaces/IWarpLink.sol
@@ -20,6 +20,8 @@ interface IWarpLink {
   error DeadlineExpired();
   error IllegalJumpInSplit();
   error JumpMustBeLastCommand();
+  error InvalidSgReceiverSender();
+  error InvalidSgReceiveSrcAddress();
 
   struct Params {
     address partner;

--- a/packages/hardhat/contracts/interfaces/external/IStargateReceiver.sol
+++ b/packages/hardhat/contracts/interfaces/external/IStargateReceiver.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+pragma solidity >=0.7.6;
+
+interface IStargateReceiver {
+  function sgReceive(
+    uint16 _srcChainId, // the remote chainId sending the tokens
+    bytes memory _srcAddress, // the remote Bridge address
+    uint256 _nonce,
+    address _token, // the token contract on the local chain
+    uint256 amountLD, // the qty of local _token contract tokens
+    bytes memory payload
+  ) external;
+}

--- a/packages/hardhat/deploy-helpers/addresses.ts
+++ b/packages/hardhat/deploy-helpers/addresses.ts
@@ -15,6 +15,10 @@ export const networkAddresses: Partial<Record<string, Partial<Record<AddressKey,
     permit2: '0x000000000022D473030F116dDEE9F6B43aC78BA3',
     stargateRouter: '0x7612aE2a34E5A363E137De748801FB4c86499152',
   },
+  optimismGoerli: {
+    weth: '0x4200000000000000000000000000000000000006',
+    stargateRouter: '0x95461eF0e0ecabC049a5c4a6B98Ca7B335FAF068',
+  },
   sepolia: {
     uniswapV2Router02: '0xC532a74256D3Db42D0Bf7a0400fEFDbad7694008',
     uniswapV2Factory: '0x7E0987E5b3a30e3f2828572Bb659A548460a3003',

--- a/packages/hardhat/deploy-helpers/addresses.ts
+++ b/packages/hardhat/deploy-helpers/addresses.ts
@@ -13,11 +13,11 @@ export const networkAddresses: Partial<Record<string, Partial<Record<AddressKey,
     uniswapV2Factory: '0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f',
     weth: '0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6',
     permit2: '0x000000000022D473030F116dDEE9F6B43aC78BA3',
-    stargateRouter: '0x7612aE2a34E5A363E137De748801FB4c86499152',
+    stargateRouter: '0x7C5B3F4865b41b9d2B6dE65fdfbB47af06AC41f0',
   },
   optimismGoerli: {
     weth: '0x4200000000000000000000000000000000000006',
-    stargateRouter: '0x95461eF0e0ecabC049a5c4a6B98Ca7B335FAF068',
+    stargateRouter: '0xb82E8737e7BA953CB4462561639f32Fd7F0974c4',
   },
   sepolia: {
     uniswapV2Router02: '0xC532a74256D3Db42D0Bf7a0400fEFDbad7694008',

--- a/packages/hardhat/deploy/003_facets.ts
+++ b/packages/hardhat/deploy/003_facets.ts
@@ -62,8 +62,8 @@ const func = async function (hre: HardhatRuntimeEnvironment) {
         address: initDeployment.address,
         calldata: initContract.interface.encodeFunctionData('init', [
           addresses.uniswapV2Router02,
-          addresses.uniswapV2Factory,
-          addresses.permit2,
+          addresses.uniswapV2Factory ?? ethers.ZeroAddress,
+          addresses.permit2 ?? ethers.ZeroAddress,
         ]),
       };
     },
@@ -83,9 +83,9 @@ const func = async function (hre: HardhatRuntimeEnvironment) {
       return {
         address: initDeployment.address,
         calldata: initContract.interface.encodeFunctionData('init', [
-          addresses.weth,
-          addresses.permit2,
-          addresses.stargateRouter ?? '0x0000000000000000000000000000000000000000',
+          addresses.weth ?? ethers.ZeroAddress,
+          addresses.permit2 ?? ethers.ZeroAddress,
+          addresses.stargateRouter ?? ethers.ZeroAddress,
         ]),
       };
     },

--- a/packages/hardhat/deploy/003_facets.ts
+++ b/packages/hardhat/deploy/003_facets.ts
@@ -12,6 +12,7 @@ const actionNames = Object.keys(FacetCutAction);
 const addresses = networkAddresses[network.name];
 
 type Init = {
+  name: string;
   address: string;
   calldata: string;
 };
@@ -59,6 +60,7 @@ const func = async function (hre: HardhatRuntimeEnvironment) {
       const initContract = await ethers.getContractAt('InitUniV2Router', initDeployment.address);
 
       return {
+        name: 'InitUniV2Router',
         address: initDeployment.address,
         calldata: initContract.interface.encodeFunctionData('init', [
           addresses.uniswapV2Router02,
@@ -81,6 +83,7 @@ const func = async function (hre: HardhatRuntimeEnvironment) {
       const initContract = await ethers.getContractAt('InitLibWarp', initDeployment.address);
 
       return {
+        name: 'InitLibWarp',
         address: initDeployment.address,
         calldata: initContract.interface.encodeFunctionData('init', [
           addresses.weth ?? ethers.ZeroAddress,
@@ -293,6 +296,7 @@ const func = async function (hre: HardhatRuntimeEnvironment) {
     );
 
     init = {
+      name: 'DiamondMultiInit',
       address: multiInitDeployment.address,
       calldata: multiInitContract.interface.encodeFunctionData('multiInit', [
         inits.map(init => init.address),
@@ -304,7 +308,8 @@ const func = async function (hre: HardhatRuntimeEnvironment) {
   }
 
   if (init) {
-    console.log(`Init: ${init.address} (${init.calldata})`);
+    console.log(`Init: ${inits.map(i => i.name).join(', ')}`);
+    console.log(`Address: ${init.address}; Calldata: (${init.calldata})`);
   }
 
   if (process.env.DRY_RUN) {

--- a/packages/hardhat/deploy/003_facets.ts
+++ b/packages/hardhat/deploy/003_facets.ts
@@ -221,7 +221,7 @@ const func = async function (hre: HardhatRuntimeEnvironment) {
   // Flatten to a single action since all remove actions use `address(0)`
   const cutsRemoveActions = Object.values(cutsRemovePerAddress).flatMap(selectors => ({
     action: FacetCutAction.Remove,
-    facetAddress: '0x0000000000000000000000000000000000000000',
+    facetAddress: ethers.ZeroAddress,
     functionSelectors: selectors,
   }));
 
@@ -320,7 +320,7 @@ const func = async function (hre: HardhatRuntimeEnvironment) {
 
   await diamondCutFacet.diamondCut(
     cuts,
-    init?.address ?? '0x0000000000000000000000000000000000000000',
+    init?.address ?? ethers.ZeroAddress,
     init?.calldata ?? Buffer.from([])
   );
 

--- a/packages/hardhat/foundry.toml
+++ b/packages/hardhat/foundry.toml
@@ -9,3 +9,11 @@ allow_paths = ["../../node_modules"]
 # See https://github.com/foundry-rs/foundry/issues/4988#issuecomment-1556331314
 evm_version = 'paris'
 solc_version = '0.8.19'
+
+[rpc_endpoints]
+goerli = "${GOERLI_RPC_URL}"
+optimism_goerli = "${OPTIMISM_GOERLI_RPC_URL}"
+
+[etherscan]
+goerli = { key = "${ETHERSCAN_API_KEY}" }
+optimism_goerli = { key = "${ETHERSCAN_API_KEY}" }

--- a/packages/hardhat/hardhat.config.ts
+++ b/packages/hardhat/hardhat.config.ts
@@ -30,7 +30,15 @@ function getNetworkUrl(name: string): string {
   }
 
   // Testnet sepolia is named sepolia. EVM forks are named fork-mainnet
-  const infuraNetworkName = name === 'sepolia' ? name : `${name}-mainnet`;
+  let infuraNetworkName: string;
+
+  if (name === 'sepolia') {
+    infuraNetworkName = name;
+  } else if (name === 'optimismGoerli') {
+    infuraNetworkName = 'optimism-goerli';
+  } else {
+    infuraNetworkName = `${name}-mainnet`;
+  }
 
   return getNetworkUrl('mainnet').replace('mainnet', infuraNetworkName);
 }
@@ -70,6 +78,12 @@ const config = {
       chainId: 5,
       gasMultiplier: 2,
     },
+    optimismGoerli: {
+      url: getNetworkUrl('optimismGoerli'),
+      accounts: { mnemonic: '' },
+      chainId: 420,
+      gasMultiplier: 10,
+    },
     sepolia: {
       url: getNetworkUrl('sepolia'),
       accounts: { mnemonic: '' },
@@ -98,10 +112,11 @@ if (ETHERSCAN_API_KEY) {
     apiKey: {
       mainnet: ETHERSCAN_API_KEY,
       goerli: ETHERSCAN_API_KEY,
+      optimismGoerli: ETHERSCAN_API_KEY,
       sepolia: ETHERSCAN_API_KEY,
       polygon: POLYGON_SCAN_API_KEY,
       arbitrumOne: ARBITRUM_SCAN_API_KEY,
-      optimisticEthereum: OPTIMISM_SCAN_API_KEY,
+      optimisticGoerli: OPTIMISM_SCAN_API_KEY,
     },
   };
 }
@@ -136,6 +151,13 @@ if (DEV_MNEMONIC) {
 
   config.networks.goerli = {
     ...config.networks.goerli,
+    accounts: {
+      mnemonic: DEV_MNEMONIC,
+    },
+  };
+
+  config.networks.optimismGoerli = {
+    ...config.networks.optimismGoerli,
     accounts: {
       mnemonic: DEV_MNEMONIC,
     },

--- a/packages/hardhat/script/jump.sol
+++ b/packages/hardhat/script/jump.sol
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import 'forge-std/console2.sol';
+import 'forge-std/Script.sol';
+import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import {SafeERC20} from '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
+import {IWarpLink} from 'contracts/interfaces/IWarpLink.sol';
+import {WarpLinkCommandTypes} from 'contracts/facets/WarpLink.sol';
+import {IStargateRouter} from 'test/foundry/helpers/IStargateRouter.sol';
+import {IAllowanceTransfer} from 'contracts/interfaces/external/IAllowanceTransfer.sol';
+import {PermitParams} from 'contracts/libraries/PermitParams.sol';
+import {Goerli, OptimismGoerli, Addresses} from '../test/foundry/helpers/Networks.sol';
+import {PermitSignature} from 'test/foundry/helpers/PermitSignature.sol';
+
+/**
+ * Bridge mock USDC from Goerli to Optimism-Goerli and invoke WarpLink on the other
+ * side, but with no commands.
+ *
+ * Adding commands would be even more interesting, but
+ * there are no actions that can be made using Statgate mock USDC.
+ *
+ * Invoke this script using:
+ * forge script script/jump.sol --rpc-url goerli --no-storage-caching -vvvv --broadcast
+ */
+contract JumpGoerli is Script, WarpLinkCommandTypes, PermitSignature {
+  address goerliDiamondAddr = 0x2A104392321e978495dBC91b68914eDbA3126D9c;
+
+  function setUp() public {}
+
+  function run() public {
+    uint256 privateKey = vm.deriveKey(vm.envString('DEV_MNEMONIC'), 1);
+    address user = vm.rememberKey(privateKey);
+
+    console2.log('User: %s', user);
+
+    uint48 deadline = uint48(block.timestamp) + 60 * 60 * 24 * 365;
+
+    IWarpLink.Params memory destParams = IWarpLink.Params({
+      tokenIn: address(0), // Unused
+      tokenOut: OptimismGoerli.STARGATE_MOCK_USDC_ADDR,
+      commands: abi.encodePacked(
+        (uint8)(0) // Command count
+      ),
+      amountIn: 0, // Unused
+      amountOut: 0, // TODO
+      recipient: user,
+      partner: address(0),
+      feeBps: 0,
+      slippageBps: 0,
+      deadline: deadline
+    });
+
+    bytes memory destParamsEncoded = abi.encode(destParams);
+
+    uint256 srcAmountIn = 100 * (10 ** 6);
+    uint256 dstGasForCall = 500_000;
+    uint16 dstChainId = OptimismGoerli.STARGATE_CHAIN_ID;
+
+    bytes memory sourceCommands = bytes.concat(
+      abi.encodePacked(
+        (uint8)(1), // Command count
+        (uint8)(COMMAND_TYPE_JUMP_STARGATE),
+        (uint16)(dstChainId), // dstChainId
+        (uint8)(1), // srcPoolId (USDC)
+        (uint8)(1), // dstPoolId (USDC),
+        uint32(dstGasForCall), // dstGasForCall
+        uint256(destParamsEncoded.length) // NOTE: Unnecessarily large type
+      ),
+      destParamsEncoded
+    );
+
+    (uint256 nativeWei, ) = IStargateRouter(Goerli.STARGATE_ROUTER_ADDR).quoteLayerZeroFee({
+      _dstChainId: dstChainId, // Goerli
+      _functionType: 1, // Swap remote
+      _toAddress: abi.encodePacked(goerliDiamondAddr),
+      _transferAndCallPayload: destParamsEncoded,
+      _lzTxParams: IStargateRouter.lzTxObj({
+        dstGasForCall: dstGasForCall,
+        dstNativeAmount: 0,
+        dstNativeAddr: ''
+      })
+    });
+
+    console2.log('Native fee: %s', nativeWei);
+
+    {
+      uint256 srcTokenInAllowance = IERC20(Goerli.STARGATE_MOCK_USDC_ADDR).allowance(
+        user,
+        address(Addresses.PERMIT2)
+      );
+
+      console2.log('srcTokenInAllowance: %s', srcTokenInAllowance);
+
+      if (srcTokenInAllowance < srcAmountIn) {
+        vm.startBroadcast(user);
+
+        SafeERC20.forceApprove(
+          IERC20(Goerli.STARGATE_MOCK_USDC_ADDR),
+          address(Addresses.PERMIT2),
+          type(uint256).max
+        );
+
+        vm.stopBroadcast();
+      }
+    }
+
+    PermitParams memory permitParams;
+
+    {
+      (, , uint48 nonce) = Addresses.PERMIT2.allowance(
+        user,
+        Goerli.STARGATE_MOCK_USDC_ADDR,
+        address(goerliDiamondAddr)
+      );
+
+      IAllowanceTransfer.PermitSingle memory permit = IAllowanceTransfer.PermitSingle(
+        IAllowanceTransfer.PermitDetails({
+          token: Goerli.STARGATE_MOCK_USDC_ADDR,
+          amount: uint160(srcAmountIn),
+          expiration: deadline,
+          nonce: nonce
+        }),
+        address(goerliDiamondAddr),
+        deadline
+      );
+
+      bytes memory sig = getPermitSignature(
+        permit,
+        privateKey,
+        Addresses.PERMIT2.DOMAIN_SEPARATOR()
+      );
+
+      permitParams = PermitParams({nonce: nonce, signature: sig});
+    }
+
+    vm.startBroadcast(user);
+
+    IWarpLink(goerliDiamondAddr).warpLinkEngage{value: nativeWei}(
+      IWarpLink.Params({
+        tokenIn: Goerli.STARGATE_MOCK_USDC_ADDR,
+        tokenOut: Goerli.STARGATE_MOCK_USDC_ADDR,
+        commands: sourceCommands,
+        amountIn: srcAmountIn,
+        amountOut: 0, // TODO
+        recipient: address(0), // Unused
+        partner: address(0), // Unused
+        feeBps: 0, // Unused
+        slippageBps: 0,
+        deadline: deadline
+      }),
+      permitParams
+    );
+
+    vm.stopBroadcast();
+  }
+}

--- a/packages/hardhat/test/foundry/helpers/IStargateRouter.sol
+++ b/packages/hardhat/test/foundry/helpers/IStargateRouter.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+interface IStargateRouter {
+  struct lzTxObj {
+    uint256 dstGasForCall;
+    uint256 dstNativeAmount;
+    bytes dstNativeAddr;
+  }
+
+  function quoteLayerZeroFee(
+    uint16 _dstChainId,
+    uint8 _functionType,
+    bytes calldata _toAddress,
+    bytes calldata _transferAndCallPayload,
+    lzTxObj memory _lzTxParams
+  ) external view returns (uint256, uint256);
+
+  function swap(
+    uint16 _dstChainId,
+    uint256 _srcPoolId,
+    uint256 _dstPoolId,
+    address payable _refundAddress,
+    uint256 _amountLD,
+    uint256 _minAmountLD,
+    lzTxObj memory _lzTxParams,
+    bytes calldata _to,
+    bytes calldata _payload
+  ) external payable;
+}

--- a/packages/hardhat/test/foundry/helpers/Networks.sol
+++ b/packages/hardhat/test/foundry/helpers/Networks.sol
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
 import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 import {IPermit2} from '../../../contracts/interfaces/external/IPermit2.sol';
 
@@ -43,6 +46,13 @@ library Optimism {
   address public constant STARGATE_ROUTER_ADDR = 0x53Bf833A5d6c4ddA888F69c22C88C9f356a41614;
 }
 
+library OptimismGoerli {
+  uint256 public constant CHAIN_ID = 420;
+  address public constant STARGATE_ROUTER_ADDR = 0xb82E8737e7BA953CB4462561639f32Fd7F0974c4;
+  address public constant STARGATE_MOCK_USDC_ADDR = 0x0CEDBAF2D0bFF895C861c5422544090EEdC653Bf;
+  uint16 public constant STARGATE_CHAIN_ID = 10132;
+}
+
 library Avalanche {
   uint256 public constant CHAIN_ID = 43114;
   address public constant STARGATE_ROUTER_ADDR = 0x45A01E4e04F14f7A4a6702c74187c5F6222033cd;
@@ -50,7 +60,9 @@ library Avalanche {
 
 library Goerli {
   uint256 public constant CHAIN_ID = 5;
-  address public constant STARGATE_ROUTER_ADDR = 0x7612aE2a34E5A363E137De748801FB4c86499152;
+  address public constant STARGATE_ROUTER_ADDR = 0x7C5B3F4865b41b9d2B6dE65fdfbB47af06AC41f0;
+  address public constant STARGATE_MOCK_USDC_ADDR = 0xDf0360Ad8C5ccf25095Aa97ee5F2785c8d848620;
+  uint16 public constant STARGATE_CHAIN_ID = 10121;
 }
 
 library Addresses {


### PR DESCRIPTION
Add support for running WarpLink commands after a Stargate jump

When a payload is passed, the recipient of the tokens becomes the Sifi contract. The Stargate router will call `sgReceive` on the Sifi contract, which in turn calls `warpLinkEngage` as if it was a user of itself.

Keep in mind that this behavior causes `msg.sender` and `address(this)` to be the Sifi contact.

The original plan was to write `sgReceive` similar to `warpLinkEngage`, meaning it calls `engageInternal`, but this does not allow handling reverts.

## Changes

- fix(harhat): remove unused `t.deadline` from WarpLink
- feat(hardhat): support post-jump commands for Stargate
