### PR TITLE
feat(frontend): dynamic swap routing

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -1,20 +1,42 @@
+import type { FunctionComponent, ReactNode } from 'react';
 import { AppProvider } from './AppProvider';
 import { FAQ } from './components/FAQ/FAQ';
 import Footer from './components/Footer/Footer';
 import { Header } from './components/Header/Header';
 import { Hero } from './components/Hero/Hero';
+import { Route, Routes } from 'react-router-dom';
+
+const Layout: FunctionComponent<{ children: ReactNode }> = ({ children }) => {
+  return (<>
+    <Header />
+      <main className="px-2 sm:px-8">
+        {children}
+      </main>
+    <Footer />
+  </>
+  );
+};
+
+const Home: FunctionComponent = () => {
+  return (
+    <>
+      <div className="mt-12 flex min-h-[90vh] flex-col md:mt-0 md:justify-center">
+        <Hero />
+      </div>
+      <FAQ />
+    </>
+  );
+}
 
 const App = () => {
   return (
     <AppProvider>
-      <Header />
-      <main className="px-2 sm:px-8">
-        <div className="mt-12 flex min-h-[90vh] flex-col md:mt-0 md:justify-center">
-          <Hero />
-        </div>
-        <FAQ />
-      </main>
-      <Footer />
+      <Layout>
+        <Routes>
+          <Route path="/:fromToken/:toToken" element={<Home />} />
+          <Route path="*" element={<Home />} />
+        </Routes>
+      </Layout>
     </AppProvider>
   );
 };

--- a/packages/frontend/src/AppProvider.tsx
+++ b/packages/frontend/src/AppProvider.tsx
@@ -2,7 +2,7 @@
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
 import type { FC, PropsWithChildren } from 'react';
-import { BrowserRouter } from 'react-router-dom';
+import { HashRouter } from 'react-router-dom';
 import { CustomToastContainer } from '@sifi/shared-ui';
 import { AnalyticsProvider } from './hooks/useAnalytics';
 import { SDKProvider } from './providers/SDKProvider';
@@ -15,7 +15,7 @@ const queryClient = new QueryClient();
 
 export const AppProvider: FC<PropsWithChildren> = ({ children }) => {
   return (
-    <BrowserRouter>
+    <HashRouter>
       <QueryProvider client={queryClient}>
         <AnalyticsProvider>
           <SDKProvider>
@@ -31,6 +31,6 @@ export const AppProvider: FC<PropsWithChildren> = ({ children }) => {
         </AnalyticsProvider>
         <ReactQueryDevtools initialIsOpen={false} />
       </QueryProvider>
-    </BrowserRouter>
+    </HashRouter>
   );
 };

--- a/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
+++ b/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
@@ -24,9 +24,11 @@ import { useSwapFormValues } from 'src/hooks/useSwapFormValues';
 import { ChainSelector } from 'src/components/ChainSelector/ChainSelector';
 import { getTokenWithNetwork } from 'src/utils/getTokenWithNetwork';
 import { useDefaultTokens } from 'src/hooks/useDefaultTokens';
+import { useTokenUrlParams } from 'src/hooks/useTokenUrlParams';
 
 const CreateSwap = () => {
   useCullQueries('quote');
+  useTokenUrlParams();
   const { address, isConnected } = useAccount();
   const sifi = useSifi();
   const {

--- a/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
+++ b/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
@@ -24,11 +24,11 @@ import { useSwapFormValues } from 'src/hooks/useSwapFormValues';
 import { ChainSelector } from 'src/components/ChainSelector/ChainSelector';
 import { getTokenWithNetwork } from 'src/utils/getTokenWithNetwork';
 import { useDefaultTokens } from 'src/hooks/useDefaultTokens';
-import { useTokenUrlParams } from 'src/hooks/useTokenUrlParams';
+import { useSyncTokenUrlParams } from 'src/hooks/useSyncTokenUrlParams';
 
 const CreateSwap = () => {
   useCullQueries('quote');
-  useTokenUrlParams();
+  useSyncTokenUrlParams();
   const { address, isConnected } = useAccount();
   const sifi = useSifi();
   const {

--- a/packages/frontend/src/hooks/useSyncTokenUrlParams.ts
+++ b/packages/frontend/src/hooks/useSyncTokenUrlParams.ts
@@ -1,18 +1,23 @@
 import { useEffect } from "react";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { useFormContext } from "react-hook-form";
 import { SUPPORTED_CHAINS, getChainById } from "src/utils/chains";
 import { isAddress } from "viem";
 import { useSwapFormValues } from "./useSwapFormValues";
 import { SwapFormKey } from "src/providers/SwapFormProvider";
+import { getTokenBySymbol } from "src/utils";
+import { useTokens } from "./useTokens";
 
 const TOKEN_ADDRESS_LENGTH = 42;
 const MIN_CHAIN_ID_LENGTH = 1;
 const MIN_TOKEN_PARAM_LENGTH = TOKEN_ADDRESS_LENGTH + MIN_CHAIN_ID_LENGTH;
 
-const useTokenUrlParams = () => {
+const useSyncTokenUrlParams = () => {
   const { fromToken: fromURLParam , toToken: toURLParam } = useParams();
-  const { fromChain, toChain } = useSwapFormValues();
+  const navigate = useNavigate();
+  const { fromChain, toChain, toToken: toTokenSymbol, fromToken: fromTokenSymbol } = useSwapFormValues();
+  const { fromTokens, toTokens } = useTokens();
+  const [toToken, fromToken] = [getTokenBySymbol(toTokenSymbol, toTokens), getTokenBySymbol(fromTokenSymbol, fromTokens)];
   const { setValue } = useFormContext();
 
   const getAddressAndChainIdFromParam = (tokenParam: string): { address: `0x${string}`, chainId: number } => {
@@ -46,20 +51,30 @@ const useTokenUrlParams = () => {
   const defaultFromToken = getDefaultAddressAndChainId(fromURLParam);
   const defaultToToken = getDefaultAddressAndChainId(toURLParam);
 
-  // Set default from and to chains if they are not set
+  const isSynchronised = defaultFromToken.address === fromToken?.address && 
+    defaultToToken.address === toToken?.address &&
+    defaultFromToken.chainId === fromChain.id &&
+    defaultToToken.chainId === toChain.id;
+
+  // Set default from and to chains on mount
   useEffect(() => {
-    if (defaultFromToken.chainId && defaultFromToken.chainId !== fromChain.id) {
+    if (!isSynchronised && defaultFromToken.chainId) {
       setValue(SwapFormKey.FromChain, getChainById(defaultFromToken.chainId));
     } 
-  }, [defaultFromToken]);
+  }, []);
 
   useEffect(() => {
     if (defaultToToken.chainId && defaultToToken.chainId !== toChain.id) {
       setValue(SwapFormKey.ToChain, getChainById(defaultToToken.chainId));
     } 
-  }, [defaultToToken]);
+  }, []);
 
-  return { defaultFromToken, defaultToToken }
+  // Update url params if the user changes the from or to token
+  useEffect(() => {
+    if (!isSynchronised && fromToken?.address && toToken?.address) {
+      navigate(`/${fromToken.address}${fromChain.id}/${toToken.address}${toChain.id}`);
+    }
+  }, [fromToken, toToken]);
 };
 
-export { useTokenUrlParams };
+export { useSyncTokenUrlParams };

--- a/packages/frontend/src/hooks/useSyncTokenUrlParams.ts
+++ b/packages/frontend/src/hooks/useSyncTokenUrlParams.ts
@@ -68,7 +68,7 @@ const useSyncTokenUrlParams = () => {
       };
     }
 
-    if (defaultToToken.chainId && defaultToToken.chainId !== toChain.id) {
+    if (!isSynchronised && defaultToToken.chainId) {
       const defaultToChain = getChainById(defaultToToken.chainId);
       
       if (defaultToChain) {
@@ -88,7 +88,7 @@ const useSyncTokenUrlParams = () => {
 
   useEffect(() => {
     const tokenlistMatchesParamChainId = toTokens[0]?.chainId === defaultToToken.chainId;
-    if (!hasSetDefaultToToken && defaultToToken.address && tokenlistMatchesParamChainId) {
+    if (!isSynchronised && !hasSetDefaultToToken && defaultToToken.address && tokenlistMatchesParamChainId) {
       setValue(SwapFormKey.ToToken, getTokenByAddress(defaultToToken.address, toTokens));
       setHasSetDefaultToToken(true);
     }

--- a/packages/frontend/src/hooks/useTokenUrlParams.ts
+++ b/packages/frontend/src/hooks/useTokenUrlParams.ts
@@ -1,0 +1,44 @@
+import { useParams } from "react-router-dom";
+import { SUPPORTED_CHAINS } from "src/utils/chains";
+import { isAddress } from "viem";
+
+const TOKEN_ADDRESS_LENGTH = 42;
+const MIN_CHAIN_ID_LENGTH = 1;
+const MIN_TOKEN_PARAM_LENGTH = TOKEN_ADDRESS_LENGTH + MIN_CHAIN_ID_LENGTH;
+
+const useTokenUrlParams = () => {
+  const { fromToken: fromURLParam , toToken: toURLParam } = useParams();
+
+  const getAddressAndChainIdFromParam = (tokenParam: string): { address: `0x${string}`, chainId: number } => {
+    const [address, chainId] = [tokenParam.slice(0, TOKEN_ADDRESS_LENGTH), tokenParam.slice(TOKEN_ADDRESS_LENGTH)];
+
+    // Typeguard
+    if (!isAddress(address)) throw new Error('Invalid address');
+
+    return { address, chainId: Number(chainId) };
+  };
+
+  const isValidTokenParam = (tokenParam?: string): boolean => {
+    if (!tokenParam) return false;
+    if (tokenParam.length < MIN_TOKEN_PARAM_LENGTH) return false;
+
+    const { address, chainId } = getAddressAndChainIdFromParam(tokenParam);
+  
+    if (!isAddress(address)) return false;
+  
+    if (!Boolean(SUPPORTED_CHAINS.find((chain) => chain.id === Number(chainId)))) return false;
+
+    return true;
+  }
+
+  const getDefaultAddressAndChainId = (urlParam?: string) => {
+    if (!urlParam || !isValidTokenParam(urlParam)) return { address: null, chainId: null };
+
+    return getAddressAndChainIdFromParam(urlParam);
+  }
+
+
+  return { defaultFromToken: getDefaultAddressAndChainId(fromURLParam), defaultToToken: getDefaultAddressAndChainId(toURLParam) }
+};
+
+export { useTokenUrlParams };

--- a/packages/frontend/src/hooks/useTokenUrlParams.ts
+++ b/packages/frontend/src/hooks/useTokenUrlParams.ts
@@ -1,6 +1,10 @@
+import { useEffect } from "react";
 import { useParams } from "react-router-dom";
-import { SUPPORTED_CHAINS } from "src/utils/chains";
+import { useFormContext } from "react-hook-form";
+import { SUPPORTED_CHAINS, getChainById } from "src/utils/chains";
 import { isAddress } from "viem";
+import { useSwapFormValues } from "./useSwapFormValues";
+import { SwapFormKey } from "src/providers/SwapFormProvider";
 
 const TOKEN_ADDRESS_LENGTH = 42;
 const MIN_CHAIN_ID_LENGTH = 1;
@@ -8,6 +12,8 @@ const MIN_TOKEN_PARAM_LENGTH = TOKEN_ADDRESS_LENGTH + MIN_CHAIN_ID_LENGTH;
 
 const useTokenUrlParams = () => {
   const { fromToken: fromURLParam , toToken: toURLParam } = useParams();
+  const { fromChain, toChain } = useSwapFormValues();
+  const { setValue } = useFormContext();
 
   const getAddressAndChainIdFromParam = (tokenParam: string): { address: `0x${string}`, chainId: number } => {
     const [address, chainId] = [tokenParam.slice(0, TOKEN_ADDRESS_LENGTH), tokenParam.slice(TOKEN_ADDRESS_LENGTH)];
@@ -35,10 +41,25 @@ const useTokenUrlParams = () => {
     if (!urlParam || !isValidTokenParam(urlParam)) return { address: null, chainId: null };
 
     return getAddressAndChainIdFromParam(urlParam);
-  }
+  };
 
+  const defaultFromToken = getDefaultAddressAndChainId(fromURLParam);
+  const defaultToToken = getDefaultAddressAndChainId(toURLParam);
 
-  return { defaultFromToken: getDefaultAddressAndChainId(fromURLParam), defaultToToken: getDefaultAddressAndChainId(toURLParam) }
+  // Set default from and to chains if they are not set
+  useEffect(() => {
+    if (defaultFromToken.chainId && defaultFromToken.chainId !== fromChain.id) {
+      setValue(SwapFormKey.FromChain, getChainById(defaultFromToken.chainId));
+    } 
+  }, [defaultFromToken]);
+
+  useEffect(() => {
+    if (defaultToToken.chainId && defaultToToken.chainId !== toChain.id) {
+      setValue(SwapFormKey.ToChain, getChainById(defaultToToken.chainId));
+    } 
+  }, [defaultToToken]);
+
+  return { defaultFromToken, defaultToToken }
 };
 
 export { useTokenUrlParams };

--- a/packages/frontend/src/utils/chains.ts
+++ b/packages/frontend/src/utils/chains.ts
@@ -36,4 +36,12 @@ function getChainIcon(chainId: number) {
   }
 }
 
-export { SUPPORTED_CHAINS, getChainIcon };
+const getChainById = (chainId: number): Chain => {
+  const chain = SUPPORTED_CHAINS.find((chain) => chain.id === chainId);
+
+  if (!chain) throw new Error(`Chain not found for chainId: ${chainId}`);
+
+  return chain;
+}
+
+export { SUPPORTED_CHAINS, getChainIcon, getChainById };

--- a/packages/frontend/src/utils/tokens.ts
+++ b/packages/frontend/src/utils/tokens.ts
@@ -17,3 +17,9 @@ export const getTokenBySymbol = (symbol: string, tokenList: Token[]) => {
 
   return tokenList.find(token => token.symbol === symbol) || null;
 };
+
+export const getTokenByAddress = (address: string, tokenList: Token[]) => {
+  if (!tokenList) return null;
+
+  return tokenList.find(token => token.address.toLowerCase() === address.toLowerCase()) || null;
+};


### PR DESCRIPTION
### Changes Made

 - Updates url to reflect the current swap
 - Sets default to from chain and swap from url on page load
 - Introduces routes, uses hash router (required to access the routes through IPFS)

### Additional Notes

 - Fetching arbitrary tokens by url is not supported here yet - to be dealt with in a follow up
 - Can store these in localstorage as well as a follow up

### Screenshots/videos

https://github.com/sideshiftfi/sifi/assets/112887817/e647994f-188d-4b6c-a5a1-f473eb9d2956


### Testing
 - [X] No mental infinite useEffect loops!
 - [X] Changing to or from token updates the url
 - [X] Changing to or from chain updates url
 - [X] Accessing a url sets chains correctly
 - [X] Accessing a url sets multichain tokens correctly
 - [X] Entering an malformed url results in the default state
 - [X] Selected "from" chain is correctly synced in state when loaded from url

### Checklist

Please tick the boxes that apply and provide additional details where necessary. Add or edit items as needed.

- [X] Changes are limited to a single goal.
- [X] Responsive design has been tested and looks good on all devices and screen sizes.
- [X] Changes have been tested on all major browsers (Chrome, Firefox, Safari).
- [X] The changes in Chromatic UI Tests all look good.
- [X] No accessibility issues have been introduced in Storybook's Accessibility tab.
- [X] The code has been optimized for performance.
