### PR TITLE
feat(frontend): cross chain jump

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@headlessui/react": "^1.7.4",
     "@heroicons/react": "^2.0.12",
-    "@sifi/sdk": "^1.8.0",
+    "@sifi/sdk": "^1.9.0",
     "@sifi/shared-ui": "^1.7.5",
     "@tanstack/react-query": "^4.13.0",
     "@uniswap/permit2-sdk": "^1.2.0",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -12,6 +12,7 @@
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "dev": "vite",
     "dev:local": "REACT_APP_BACKEND_OVERRIDE=localhost vite",
+    "test": "vitest",
     "lint": "eslint \"./src/**/*.{js,jsx,ts,tsx}\" || true",
     "preview": "vite preview",
     "storybook": "env STORYBOOK_DEV=true storybook dev -p 6006",
@@ -19,6 +20,9 @@
     "chromatic": "npx chromatic --project-token=c1d7701999bd --exit-zero-on-changes"
   },
   "dependencies": {
+    "@ethersproject/abstract-signer": "^5.6.1",
+    "@ethersproject/hash": "^5.6.1",
+    "@ethersproject/providers": "^5.6.1",
     "@headlessui/react": "^1.7.4",
     "@heroicons/react": "^2.0.12",
     "@sifi/sdk": "^1.9.0",
@@ -33,9 +37,6 @@
     "bn.js": "5.2.1",
     "debounce": "^1.2.1",
     "ethers": "^5.6.1",
-    "@ethersproject/abstract-signer": "^5.6.1",
-    "@ethersproject/hash": "^5.6.1",
-    "@ethersproject/providers": "^5.6.1",
     "hash.js": "1.1.7",
     "js-sha3": "0.8.0",
     "react": "^18.2.0",
@@ -80,7 +81,8 @@
     "storybook": "7.3.2",
     "typescript": "^5.2.2",
     "vite": "^4.1.3",
-    "vite-plugin-svgr": "3.2.0"
+    "vite-plugin-svgr": "3.2.0",
+    "vitest": "^0.34.6"
   },
   "msw": {
     "workerDirectory": "public"

--- a/packages/frontend/src/components/ChainSelector/ChainSelector.stories.tsx
+++ b/packages/frontend/src/components/ChainSelector/ChainSelector.stories.tsx
@@ -1,0 +1,21 @@
+import { userEvent, within } from '@storybook/testing-library';
+import { ChainSelector } from './ChainSelector';
+import { MockWagmiDecorator } from '../../../.storybook/decorators/wagmiDecorator';
+import { SwapFormKey } from 'src/providers/SwapFormProvider';
+
+export default {
+  title: 'Components/ChainSelector',
+  component: ChainSelector,
+  decorators: [MockWagmiDecorator()],
+};
+
+const Default = () => <ChainSelector chainToSet={SwapFormKey.FromChain} />;
+
+const Open = () => <ChainSelector chainToSet={SwapFormKey.ToChain} />;
+
+Open.play = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+  const canvas = within(canvasElement);
+  userEvent.click(await canvas.findByRole('button'));
+};
+
+export { Default, Open };

--- a/packages/frontend/src/components/ChainSelector/ChainSelector.tsx
+++ b/packages/frontend/src/components/ChainSelector/ChainSelector.tsx
@@ -1,0 +1,112 @@
+import { Fragment } from 'react';
+import { Listbox, Transition } from '@headlessui/react';
+import { ReactComponent as DownCaret } from 'src/assets/down-caret.svg';
+import { SUPPORTED_CHAINS, getChainIcon } from 'src/utils/chains';
+import { Chain, useNetwork, useSwitchNetwork } from 'wagmi';
+import { SwapFormKey } from 'src/providers/SwapFormProvider';
+import { useFormContext } from 'react-hook-form';
+import { useSwapFormValues } from 'src/hooks/useSwapFormValues';
+
+type ChainSelectorProps = {
+  chainToSet: SwapFormKey.FromChain | SwapFormKey.ToChain;
+};
+
+const ChainSelector: React.FC<ChainSelectorProps> = ({ chainToSet }) => {
+  const { chain: activeChain } = useNetwork();
+  const { switchNetwork } = useSwitchNetwork();
+  const { setValue } = useFormContext();
+  const { fromChain, toChain } = useSwapFormValues();
+
+  const selectedChain = chainToSet === SwapFormKey.FromChain ? fromChain : toChain;
+
+  const handleChange = (chain: Chain) => {
+    setValue(chainToSet, chain);
+
+    if (chainToSet === SwapFormKey.ToChain || !switchNetwork) return;
+
+    switchNetwork(chain.id);
+  };
+
+  return (
+    <div className="font-text relative flex justify-end top-[1rem]">
+      <Listbox value={fromChain} onChange={handleChange}>
+        <div className="relative pr-0">
+          <Listbox.Button
+            role="button"
+            className="dark:text-flashbang-white text-new-black border-new-black dark:border-darker-gray font-display flex h-12
+            items-center gap-3 rounded-md border-0 px-4 py-2 text-sm max-[340px]:gap-3 sm:border-2 md:text-base"
+            aria-busy="true"
+          >
+            {selectedChain && (
+              <div className="flex items-center">
+                <img
+                  src={getChainIcon(selectedChain.id)}
+                  alt={selectedChain.name}
+                  className="w-6 mr-2"
+                />
+                <span>{selectedChain.name} </span>
+              </div>
+            )}
+            <DownCaret
+              className={`text-new-black dark:text-flashbang-white w-4
+
+              `}
+              aria-hidden="true"
+            />
+          </Listbox.Button>
+          <Transition
+            as={Fragment}
+            enter="transition ease-out duration-100"
+            enterFrom="transform opacity-0 scale-95"
+            enterTo="transform opacity-100 scale-100"
+            leave="transition ease-in duration-75"
+            leaveFrom="transform opacity-100 scale-100"
+            leaveTo="transform opacity-0 scale-95"
+          >
+            <Listbox.Options
+              className="dark:bg-new-black text-new-black dark:text-flashbang-white bg-cyber-gray absolute right-0 z-30 mt-2 flex max-h-[80vh]
+              w-full min-w-[16rem] origin-top-right flex-col overflow-y-auto rounded-sm shadow-lg drop-shadow-xs-strong outline-none"
+              aria-busy="true"
+            >
+              <div className="font-display bg-flashbang-white flex flex-col gap-y-2 p-6 text-sm dark:bg-darkest-gray mr-3  rounded-sm">
+                {Object.values(SUPPORTED_CHAINS).map(chain => (
+                  <Listbox.Option
+                    key={chain.name}
+                    className={() =>
+                      `dark:text-flashbang-white text-new-black font-display block cursor-pointer text-left text-base no-underline transition`
+                    }
+                    value={chain}
+                  >
+                    {({ selected }) => (
+                      <div
+                        className={`flex rounded-xl place-items-center justify-between p-2  ${
+                          selected
+                            ? 'bg-dark-gray bg-opacity-20'
+                            : 'hover:bg-flashbang-white hover:bg-opacity-10 ease-linear transition-all'
+                        } `}
+                      >
+                        <div className="flex">
+                          <div className="mr-3">
+                            <img src={getChainIcon(chain.id)} alt={chain.name} className="w-6" />
+                          </div>
+                          <span>{chain.name}</span>
+                        </div>
+                        {chain.id === activeChain?.id && (
+                          <div>
+                            <div className="w-2 h-2 bg-emerald-green rounded-full relative drop-shadow-xs-strong" />
+                          </div>
+                        )}
+                      </div>
+                    )}
+                  </Listbox.Option>
+                ))}
+              </div>
+            </Listbox.Options>
+          </Transition>
+        </div>
+      </Listbox>
+    </div>
+  );
+};
+
+export { ChainSelector };

--- a/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
+++ b/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
@@ -20,7 +20,6 @@ import { SwapInformation } from '../SwapInformation';
 import { MulticallToken } from 'src/types';
 import { useMultiCallTokenBalance } from 'src/hooks/useMulticallTokenBalance';
 import { usePermit2 } from 'src/hooks/usePermit2';
-import { getChainIcon } from 'src/utils/chains';
 import { useSwapFormValues } from 'src/hooks/useSwapFormValues';
 import { ChainSelector } from 'src/components/ChainSelector/ChainSelector';
 import { getTokenWithNetwork } from 'src/utils/getTokenWithNetwork';
@@ -116,7 +115,7 @@ const CreateSwap = () => {
         setIsLoading(false);
       },
       onSuccess: async hash => {
-        const explorerLink = toChain ? getEvmTxUrl(toChain, hash) : undefined;
+        const explorerLink = fromChain ? getEvmTxUrl(fromChain, hash) : undefined;
 
         showToast({
           text: 'Your swap has been confirmed. Please stand by.',

--- a/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
+++ b/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
@@ -20,7 +20,9 @@ import { SwapInformation } from '../SwapInformation';
 import { MulticallToken } from 'src/types';
 import { useMultiCallTokenBalance } from 'src/hooks/useMulticallTokenBalance';
 import { usePermit2 } from 'src/hooks/usePermit2';
+import { getChainIcon } from 'src/utils/chains';
 import { useSwapFormValues } from 'src/hooks/useSwapFormValues';
+import { ChainSelector } from 'src/components/ChainSelector/ChainSelector';
 import { getTokenWithNetwork } from 'src/utils/getTokenWithNetwork';
 
 const CreateSwap = () => {
@@ -45,7 +47,7 @@ const CreateSwap = () => {
   const toToken = getTokenBySymbol(toTokenSymbol, tokens);
   const [isLoading, setIsLoading] = useState(false);
   const { quote, isFetching: isFetchingQuote } = useQuote();
-  const ShiftInputLabel = { from: 'You pay', to: 'You receive' } as const;
+  const ShiftInputLabel = { from: 'From', to: 'To' } as const;
   const { data: fromBalance, refetch: refetchFromBalance } = useTokenBalance(fromToken);
   const { data: toBalance, refetch: refetchToBalance } = useTokenBalance(toToken);
   const { getPermit2Params } = usePermit2();
@@ -188,6 +190,10 @@ const CreateSwap = () => {
           <div>
             <div className="py-4">
               <div className="mb-2">
+                <div className="flex justify-between align-bottom items-end">
+                  <div className="font-display text-smoke">{ShiftInputLabel.from}</div>
+                  <ChainSelector chainToSet={SwapFormKey.FromChain} />
+                </div>
                 <ShiftInput
                   label={ShiftInputLabel.from}
                   balance={fromBalance?.formatted}
@@ -197,7 +203,12 @@ const CreateSwap = () => {
                   formMethods={methods}
                   disabled={Boolean(isSameTokenPair)}
                   max={depositMax}
+                  hideLabel
                 />
+              </div>
+              <div className="flex justify-between align-bottom items-end">
+                <div className="font-display text-smoke">{ShiftInputLabel.to}</div>
+                <ChainSelector chainToSet={SwapFormKey.ToChain} />
               </div>
               <ShiftInput
                 label={ShiftInputLabel.to}
@@ -208,6 +219,7 @@ const CreateSwap = () => {
                 disabled
                 openSelector={() => openTokenSelector('to')}
                 formMethods={methods}
+                hideLabel
               />
               <TokenSelector
                 balanceMap={balanceMap}

--- a/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
+++ b/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
@@ -45,6 +45,8 @@ const CreateSwap = () => {
 
   const { balanceMap: toTokenBalanceMap, refetch: refetchToTokenBalances } =
     useMultiCallTokenBalance(toTokens as MulticallToken[], toChain.id);
+  const fromToken = getTokenBySymbol(fromTokenSymbol, fromTokens);
+  const toToken = getTokenBySymbol(toTokenSymbol, toTokens);
   const [isLoading, setIsLoading] = useState(false);
   const { quote, isFetching: isFetchingQuote } = useQuote();
   const ShiftInputLabel = { from: 'From', to: 'To' } as const;

--- a/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
+++ b/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
@@ -54,7 +54,8 @@ const CreateSwap = () => {
   );
   const { data: toBalance, refetch: refetchToBalance } = useTokenBalance(toToken, toChain.id);
   const { getPermit2Params } = usePermit2();
-  const isSameTokenPair = fromToken && toToken && fromToken.address === toToken.address;
+  const isSameTokenPair =
+    fromToken && toToken && fromToken.address === toToken.address && fromChain === toChain;
 
   const isToSwapInputLoading = isFetchingQuote;
 

--- a/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
+++ b/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
@@ -146,22 +146,19 @@ const CreateSwap = () => {
     setIsLoading(true);
     mutation.mutate();
   };
-
   const { closeTokenSelector, openTokenSelector, tokenSelectorType, isTokenSelectorOpen } =
     useTokenSelector();
 
-  const { setValue, watch } = useFormContext();
+  const { setValue } = useFormContext();
   const methods = useFormContext();
-
   const fromTokenKey = SwapFormKeyHelper.getTokenKey('from');
   const toTokenKey = SwapFormKeyHelper.getTokenKey('to');
-  const selectedFromToken = getTokenBySymbol(watch(fromTokenKey), fromTokens) || undefined;
-  const selectedToToken = getTokenBySymbol(watch(toTokenKey), toTokens) || undefined;
+  const selectedFromToken = getTokenBySymbol(fromTokenSymbol, fromTokens) || undefined;
+  const selectedToToken = getTokenBySymbol(toTokenSymbol, toTokens) || undefined;
   const fromId = SwapFormKeyHelper.getAmountKey('from');
   const toId = SwapFormKeyHelper.getAmountKey('to');
   const spendableBalance = useSpendableBalance({ token: fromToken });
   const depositMax = isConnected ? spendableBalance : undefined;
-
   const selectedFromTokenWithNetwork = getTokenWithNetwork(selectedFromToken, fromChain);
   const selectedToTokenWithNetwork = getTokenWithNetwork(selectedToToken, toChain);
 

--- a/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
+++ b/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
@@ -48,8 +48,11 @@ const CreateSwap = () => {
   const [isLoading, setIsLoading] = useState(false);
   const { quote, isFetching: isFetchingQuote } = useQuote();
   const ShiftInputLabel = { from: 'From', to: 'To' } as const;
-  const { data: fromBalance, refetch: refetchFromBalance } = useTokenBalance(fromToken);
-  const { data: toBalance, refetch: refetchToBalance } = useTokenBalance(toToken);
+  const { data: fromBalance, refetch: refetchFromBalance } = useTokenBalance(
+    fromToken,
+    fromChain.id
+  );
+  const { data: toBalance, refetch: refetchToBalance } = useTokenBalance(toToken, toChain.id);
   const { getPermit2Params } = usePermit2();
   const isSameTokenPair = fromToken && toToken && fromToken.address === toToken.address;
 
@@ -127,7 +130,8 @@ const CreateSwap = () => {
 
         refetchFromBalance();
         refetchToBalance();
-        refetchTokenBalances();
+        refetchFromTokenBalances();
+        refetchToTokenBalances();
         setValue(SwapFormKey.FromAmount, '');
       },
     }

--- a/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
+++ b/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
@@ -116,7 +116,7 @@ const CreateSwap = () => {
         setIsLoading(false);
       },
       onSuccess: async hash => {
-        const explorerLink = getEvmTxUrl(fromChain, hash);
+        const explorerLink = toChain ? getEvmTxUrl(toChain, hash) : undefined;
 
         showToast({
           text: 'Your swap has been confirmed. Please stand by.',

--- a/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
+++ b/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
@@ -40,11 +40,11 @@ const CreateSwap = () => {
   const { data: walletClient } = useWalletClient();
   const { handleSubmit } = useForm();
   const { fromTokens, toTokens } = useTokens();
-  const { balanceMap, refetch: refetchTokenBalances } = useMultiCallTokenBalance(
-    tokens as MulticallToken[]
-  );
-  const fromToken = getTokenBySymbol(fromTokenSymbol, tokens);
-  const toToken = getTokenBySymbol(toTokenSymbol, tokens);
+  const { balanceMap: fromBalanceMap, refetch: refetchFromTokenBalances } =
+    useMultiCallTokenBalance(fromTokens as MulticallToken[], fromChain.id);
+
+  const { balanceMap: toTokenBalanceMap, refetch: refetchToTokenBalances } =
+    useMultiCallTokenBalance(toTokens as MulticallToken[], toChain.id);
   const [isLoading, setIsLoading] = useState(false);
   const { quote, isFetching: isFetchingQuote } = useQuote();
   const ShiftInputLabel = { from: 'From', to: 'To' } as const;
@@ -229,7 +229,7 @@ const CreateSwap = () => {
                 hideLabel
               />
               <TokenSelector
-                balanceMap={balanceMap}
+                balanceMap={tokenSelectorType === 'from' ? fromBalanceMap : toTokenBalanceMap}
                 close={closeTokenSelector}
                 isOpen={isTokenSelectorOpen}
                 type={tokenSelectorType}

--- a/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
+++ b/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
@@ -23,6 +23,7 @@ import { usePermit2 } from 'src/hooks/usePermit2';
 import { useSwapFormValues } from 'src/hooks/useSwapFormValues';
 import { ChainSelector } from 'src/components/ChainSelector/ChainSelector';
 import { getTokenWithNetwork } from 'src/utils/getTokenWithNetwork';
+import { useDefaultTokens } from 'src/hooks/useDefaultTokens';
 
 const CreateSwap = () => {
   useCullQueries('quote');
@@ -61,6 +62,7 @@ const CreateSwap = () => {
   const isToSwapInputLoading = isFetchingQuote;
 
   useReferrer();
+  useDefaultTokens();
 
   const mutation = useMutation(
     async () => {
@@ -151,8 +153,6 @@ const CreateSwap = () => {
 
   const { setValue } = useFormContext();
   const methods = useFormContext();
-  const fromTokenKey = SwapFormKeyHelper.getTokenKey('from');
-  const toTokenKey = SwapFormKeyHelper.getTokenKey('to');
   const selectedFromToken = getTokenBySymbol(fromTokenSymbol, fromTokens) || undefined;
   const selectedToToken = getTokenBySymbol(toTokenSymbol, toTokens) || undefined;
   const fromId = SwapFormKeyHelper.getAmountKey('from');
@@ -166,15 +166,6 @@ const CreateSwap = () => {
     setValue(SwapFormKey.FromAmount, '');
     setValue(SwapFormKey.ToAmount, '');
   };
-
-  useEffect(() => {
-    if (fromTokens.length > 1) {
-      setValue(fromTokenKey, fromTokens[0].symbol);
-    }
-    if (toTokens.length > 1) {
-      setValue(toTokenKey, toTokens[1].symbol);
-    }
-  }, [fromTokens, toTokens]);
 
   useEffect(() => {
     if (isSameTokenPair) {

--- a/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
+++ b/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
@@ -39,7 +39,7 @@ const CreateSwap = () => {
   const publicClient = usePublicClient({ chainId: fromChain.id });
   const { data: walletClient } = useWalletClient();
   const { handleSubmit } = useForm();
-  const { tokens } = useTokens();
+  const { fromTokens, toTokens } = useTokens();
   const { balanceMap, refetch: refetchTokenBalances } = useMultiCallTokenBalance(
     tokens as MulticallToken[]
   );
@@ -153,8 +153,8 @@ const CreateSwap = () => {
 
   const fromTokenKey = SwapFormKeyHelper.getTokenKey('from');
   const toTokenKey = SwapFormKeyHelper.getTokenKey('to');
-  const selectedFromToken = getTokenBySymbol(watch(fromTokenKey), tokens) || undefined;
-  const selectedToToken = getTokenBySymbol(watch(toTokenKey), tokens) || undefined;
+  const selectedFromToken = getTokenBySymbol(watch(fromTokenKey), fromTokens) || undefined;
+  const selectedToToken = getTokenBySymbol(watch(toTokenKey), toTokens) || undefined;
   const fromId = SwapFormKeyHelper.getAmountKey('from');
   const toId = SwapFormKeyHelper.getAmountKey('to');
   const spendableBalance = useSpendableBalance({ token: fromToken });
@@ -169,11 +169,13 @@ const CreateSwap = () => {
   };
 
   useEffect(() => {
-    if (tokens.length > 1) {
-      setValue(fromTokenKey, tokens[0].symbol);
-      setValue(toTokenKey, tokens[1].symbol);
+    if (fromTokens.length > 1) {
+      setValue(fromTokenKey, fromTokens[0].symbol);
     }
-  }, [tokens]);
+    if (toTokens.length > 1) {
+      setValue(toTokenKey, toTokens[1].symbol);
+    }
+  }, [fromTokens, toTokens]);
 
   useEffect(() => {
     if (isSameTokenPair) {

--- a/packages/frontend/src/components/CreateSwapButtons/CreateSwapButtons.tsx
+++ b/packages/frontend/src/components/CreateSwapButtons/CreateSwapButtons.tsx
@@ -59,7 +59,7 @@ const CreateSwapButtons = ({ isLoading }: { isLoading: boolean }) => {
     !isValidTokenAmount(fromAmount);
 
   const getShiftButtonLabel = () => {
-    if (fromToken?.address === toToken?.address) {
+    if (fromToken?.address === toToken?.address && fromChain === toChain) {
       return 'Cannot shift same tokens';
     }
 

--- a/packages/frontend/src/components/CreateSwapButtons/CreateSwapButtons.tsx
+++ b/packages/frontend/src/components/CreateSwapButtons/CreateSwapButtons.tsx
@@ -21,7 +21,7 @@ const CreateSwapButtons = ({ isLoading }: { isLoading: boolean }) => {
   const { isConnected } = useAccount();
   const { quote, isFetching: isFetchingQuote } = useQuote();
   const { chain } = useNetwork();
-  const { tokens } = useTokens();
+  const { fromTokens, toTokens } = useTokens();
   const { isLoading: isApproving } = useApprove();
   const { allowance, isAllowanceAboveFromAmount, isFetching: isFetchingAllowance } = useAllowance();
   const [fromTokenSymbol, toTokenSymbol, fromAmount] = useWatch({
@@ -29,12 +29,14 @@ const CreateSwapButtons = ({ isLoading }: { isLoading: boolean }) => {
   });
   const fromToken = getTokenBySymbol(fromTokenSymbol, tokens);
   const toToken = getTokenBySymbol(toTokenSymbol, tokens);
+  const fromToken = getTokenBySymbol(fromTokenSymbol, fromTokens);
+  const toToken = getTokenBySymbol(toTokenSymbol, toTokens);
   const isFromEthereum = fromToken?.address === ETH_CONTRACT_ADDRESS;
   const userIsConnectedToWrongNetwork = Boolean(
     chain?.id && fromToken?.chainId && chain.id !== fromToken.chainId
   );
   const { data: fromBalance } = useTokenBalance(fromToken);
-  const fromAmountInWei =  fromToken ? parseUnits(fromAmount || '0', fromToken.decimals) : BigInt(0);
+  const fromAmountInWei = fromToken ? parseUnits(fromAmount || '0', fromToken.decimals) : BigInt(0);
   const hasSufficientBalance = quote && fromBalance && fromBalance.value >= fromAmountInWei;
 
   const isShiftButtonLoading = isLoading || isFetchingAllowance || isFetchingQuote;

--- a/packages/frontend/src/components/CreateSwapButtons/CreateSwapButtons.tsx
+++ b/packages/frontend/src/components/CreateSwapButtons/CreateSwapButtons.tsx
@@ -36,7 +36,7 @@ const CreateSwapButtons = ({ isLoading }: { isLoading: boolean }) => {
   const userIsConnectedToWrongNetwork = Boolean(
     chain?.id && fromToken?.chainId && chain.id !== fromToken.chainId
   );
-  const { data: fromBalance } = useTokenBalance(fromToken);
+  const { data: fromBalance } = useTokenBalance(fromToken, fromChain.id);
   const fromAmountInWei = fromToken ? parseUnits(fromAmount || '0', fromToken.decimals) : BigInt(0);
   const hasSufficientBalance = quote && fromBalance && fromBalance.value >= fromAmountInWei;
 

--- a/packages/frontend/src/components/CreateSwapButtons/CreateSwapButtons.tsx
+++ b/packages/frontend/src/components/CreateSwapButtons/CreateSwapButtons.tsx
@@ -1,4 +1,3 @@
-import { useWatch } from 'react-hook-form';
 import { useAccount, useNetwork } from 'wagmi';
 import { parseUnits } from 'viem';
 import { useCullQueries } from 'src/hooks/useCullQueries';
@@ -6,7 +5,6 @@ import { useAllowance } from 'src/hooks/useAllowance';
 import { useApprove } from 'src/hooks/useApprove';
 import { useTokens } from 'src/hooks/useTokens';
 import { useQuote } from 'src/hooks/useQuote';
-import { SwapFormKey } from 'src/providers/SwapFormProvider';
 import { getTokenBySymbol, isValidTokenAmount } from 'src/utils';
 import { ETH_CONTRACT_ADDRESS } from 'src/constants';
 import { useTokenBalance } from 'src/hooks/useTokenBalance';
@@ -14,6 +12,7 @@ import { ApproveButton } from './ApproveButton';
 import { SwitchNetworkButton } from './SwitchNetworkButton';
 import { Button } from '../Button';
 import { ConnectWallet } from '../ConnectWallet/ConnectWallet';
+import { useSwapFormValues } from 'src/hooks/useSwapFormValues';
 
 const CreateSwapButtons = ({ isLoading }: { isLoading: boolean }) => {
   useCullQueries('routes');
@@ -24,11 +23,13 @@ const CreateSwapButtons = ({ isLoading }: { isLoading: boolean }) => {
   const { fromTokens, toTokens } = useTokens();
   const { isLoading: isApproving } = useApprove();
   const { allowance, isAllowanceAboveFromAmount, isFetching: isFetchingAllowance } = useAllowance();
-  const [fromTokenSymbol, toTokenSymbol, fromAmount] = useWatch({
-    name: [SwapFormKey.FromToken, SwapFormKey.ToToken, SwapFormKey.FromAmount],
-  });
-  const fromToken = getTokenBySymbol(fromTokenSymbol, tokens);
-  const toToken = getTokenBySymbol(toTokenSymbol, tokens);
+  const {
+    fromToken: fromTokenSymbol,
+    toToken: toTokenSymbol,
+    fromAmount,
+    fromChain,
+    toChain,
+  } = useSwapFormValues();
   const fromToken = getTokenBySymbol(fromTokenSymbol, fromTokens);
   const toToken = getTokenBySymbol(toTokenSymbol, toTokens);
   const isFromEthereum = fromToken?.address === ETH_CONTRACT_ADDRESS;

--- a/packages/frontend/src/components/CreateSwapButtons/SwitchNetworkButton.tsx
+++ b/packages/frontend/src/components/CreateSwapButtons/SwitchNetworkButton.tsx
@@ -6,9 +6,9 @@ import { useSwapFormValues } from 'src/hooks/useSwapFormValues';
 
 const SwitchNetworkButton = () => {
   const { switchNetwork, isLoading: isSwitchingNetwork } = useSwitchNetwork();
-  const { tokens } = useTokens();
+  const { fromTokens } = useTokens();
   const { fromToken: fromTokenSymbol } = useSwapFormValues();
-  const fromToken = getTokenBySymbol(fromTokenSymbol, tokens);
+  const fromToken = getTokenBySymbol(fromTokenSymbol, fromTokens);
 
   const handleSwitchNetwork = () => {
     if (!fromToken || !switchNetwork) return;

--- a/packages/frontend/src/components/Header/Header.tsx
+++ b/packages/frontend/src/components/Header/Header.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent } from 'react';
 import { Navbar } from '@sifi/shared-ui';
 import logo from 'src/assets/logoWhite.svg';
 import HeaderMenu from '../HeaderMenu/HeaderMenu';
-import { NetworkSelector } from '../NetworkSelector/NetworkSelector';
+import { HeaderChainSelector } from '../HeaderChainSelector/HeaderChainSelector';
 
 const Header: FunctionComponent = () => {
   const navLinks = [
@@ -15,7 +15,7 @@ const Header: FunctionComponent = () => {
 
   return (
     <Navbar logo={logo} navLinks={navLinks}>
-      <NetworkSelector />
+      <HeaderChainSelector />
       <HeaderMenu />
     </Navbar>
   );

--- a/packages/frontend/src/components/HeaderChainSelector/HeaderChainSelector.stories.tsx
+++ b/packages/frontend/src/components/HeaderChainSelector/HeaderChainSelector.stories.tsx
@@ -1,16 +1,16 @@
 import { userEvent, within } from '@storybook/testing-library';
-import { NetworkSelector } from './NetworkSelector';
+import { HeaderChainSelector } from './HeaderChainSelector';
 import { MockWagmiDecorator } from '../../../.storybook/decorators/wagmiDecorator';
 
 export default {
-  title: 'Components/NetworkSelector',
-  component: NetworkSelector,
+  title: 'Components/HeaderChainSelector',
+  component: HeaderChainSelector,
   decorators: [MockWagmiDecorator()],
 };
 
-const Default = () => <NetworkSelector />;
+const Default = () => <HeaderChainSelector />;
 
-const Open = () => <NetworkSelector />;
+const Open = () => <HeaderChainSelector />;
 
 Open.play = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
   const canvas = within(canvasElement);

--- a/packages/frontend/src/components/HeaderChainSelector/HeaderChainSelector.tsx
+++ b/packages/frontend/src/components/HeaderChainSelector/HeaderChainSelector.tsx
@@ -7,7 +7,7 @@ import { SwapFormKey } from 'src/providers/SwapFormProvider';
 import { useFormContext } from 'react-hook-form';
 import { useSwapFormValues } from 'src/hooks/useSwapFormValues';
 
-const NetworkSelector: React.FC = () => {
+const HeaderChainSelector: React.FC = () => {
   const { chain: activeChain } = useNetwork();
   const { switchNetwork } = useSwitchNetwork();
   const { setValue } = useFormContext();
@@ -96,4 +96,4 @@ const NetworkSelector: React.FC = () => {
   );
 };
 
-export { NetworkSelector };
+export { HeaderChainSelector };

--- a/packages/frontend/src/components/Hero/Hero.tsx
+++ b/packages/frontend/src/components/Hero/Hero.tsx
@@ -3,8 +3,8 @@ import { CreateSwap } from '../CreateSwap/CreateSwap';
 const Hero = () => (
   <div className="mx-auto flex w-full max-w-[67rem] flex-wrap justify-center px-4 py-4 sm:px-8 lg:px-16">
     <div className="w-full flex-col items-center justify-center md:w-[50%] md:pb-16">
-      <h1 className="text-flashbang-white font-display mb-4 text-center text-[1.875rem] sm:text-[2.25rem] md:text-[3rem]">
-        On-Chain Swap
+      <h1 className="text-flashbang-white font-display mb-4 text-center text-[1.875rem] sm:text-[2.25rem]">
+        Cross Chain Jump
       </h1>
       <div className="border-darker-gray mx-auto mb-4 max-w-[27rem] border-b-[1px]">
         <CreateSwap />

--- a/packages/frontend/src/components/NetworkSelector/NetworkSelector.tsx
+++ b/packages/frontend/src/components/NetworkSelector/NetworkSelector.tsx
@@ -1,7 +1,6 @@
 import { Fragment } from 'react';
 import { Listbox, Transition } from '@headlessui/react';
 import { ReactComponent as DownCaret } from 'src/assets/down-caret.svg';
-import { enableMultipleChains } from 'src/utils/featureFlags';
 import { SUPPORTED_CHAINS, getChainIcon } from 'src/utils/chains';
 import { Chain, useNetwork, useSwitchNetwork } from 'wagmi';
 import { SwapFormKey } from 'src/providers/SwapFormProvider';
@@ -14,14 +13,8 @@ const NetworkSelector: React.FC = () => {
   const { setValue } = useFormContext();
   const { fromChain } = useSwapFormValues();
 
-  const chains = enableMultipleChains
-    ? Object.values(SUPPORTED_CHAINS)
-    : Object.values(SUPPORTED_CHAINS).filter(chain => chain.id === 1);
-
   const handleChange = (chain: Chain) => {
     setValue(SwapFormKey.FromChain, chain);
-    // TODO: Remove when cross-chain is enabled
-    setValue(SwapFormKey.ToChain, chain);
 
     if (!switchNetwork) return;
 
@@ -63,7 +56,7 @@ const NetworkSelector: React.FC = () => {
               aria-busy="true"
             >
               <div className="font-display bg-flashbang-white flex flex-col gap-y-2 p-6 text-sm dark:bg-darkest-gray mr-3  rounded-sm">
-                {Object.values(chains).map(chain => (
+                {Object.values(SUPPORTED_CHAINS).map(chain => (
                   <Listbox.Option
                     key={chain.name}
                     className={() =>

--- a/packages/frontend/src/components/TokenSelector/TokenSelector.tsx
+++ b/packages/frontend/src/components/TokenSelector/TokenSelector.tsx
@@ -15,7 +15,9 @@ const TokenSelector: FunctionComponent<{
 }> = ({ isOpen, close, type, balanceMap }) => {
   const selectId = SwapFormKeyHelper.getTokenKey(type);
   const { address } = useAccount();
-  const { tokens, fetchTokenByAddress } = useTokens();
+  const { fromTokens, toTokens, fetchFromTokenByAddress, fetchToTokenByAddress } = useTokens();
+  const tokens = type === 'from' ? fromTokens : toTokens;
+  const fetchTokenByAddress = type === 'from' ? fetchFromTokenByAddress : fetchToTokenByAddress;
   const { setValue, watch } = useFormContext();
   const selectedToken = getTokenBySymbol(watch(selectId), tokens);
 
@@ -26,21 +28,21 @@ const TokenSelector: FunctionComponent<{
     setValue(selectId, newToken.symbol);
   };
 
-  const formattedTokens = useMemo(
-    () =>{
-      return tokens?.map(token => {
-        const balance = balanceMap?.get(token.address.toLowerCase() as `0x${string}`)?.toString() || undefined;
-        return {
-          id: token.address as `0x${string}`,
-          logoURI: token.logoURI,
-          name: token.name,
-          networkDisplayName: null,
-          symbol: token.symbol,
-          networkLogoURI: null,
-          balance,
-        }})},
-    [tokens, balanceMap, address]
-  );
+  const formattedTokens = useMemo(() => {
+    return tokens?.map(token => {
+      const balance =
+        balanceMap?.get(token.address.toLowerCase() as `0x${string}`)?.toString() || undefined;
+      return {
+        id: token.address as `0x${string}`,
+        logoURI: token.logoURI,
+        name: token.name,
+        networkDisplayName: null,
+        symbol: token.symbol,
+        networkLogoURI: null,
+        balance,
+      };
+    });
+  }, [tokens, balanceMap, address]);
 
   if (!formattedTokens) return null;
 

--- a/packages/frontend/src/hooks/useAllowance.tsx
+++ b/packages/frontend/src/hooks/useAllowance.tsx
@@ -8,14 +8,14 @@ import { useSwapFormValues } from './useSwapFormValues';
 
 const useAllowance = () => {
   const { quote, isFetching: isFetchingQuote } = useQuote();
-  const { tokens } = useTokens();
+  const { fromTokens } = useTokens();
   const { isConnected, address } = useAccount();
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const approveAddress = (quote?.permit2Address || quote?.approveAddress) as `0x${string}`;
 
   const { fromToken: fromTokenSymbol, fromAmount } = useSwapFormValues();
 
-  const fromToken = getTokenBySymbol(fromTokenSymbol, tokens);
+  const fromToken = getTokenBySymbol(fromTokenSymbol, fromTokens);
 
   const enabled =
     !!fromToken &&

--- a/packages/frontend/src/hooks/useApprove.tsx
+++ b/packages/frontend/src/hooks/useApprove.tsx
@@ -15,12 +15,12 @@ const useApprove = () => {
   const { data: walletClient } = useWalletClient();
   const [isLoading, setIsLoading] = useState(false);
   const { quote } = useQuote();
-  const { tokens } = useTokens();
+  const { fromTokens } = useTokens();
   const approveAddress = (quote?.permit2Address || quote?.approveAddress) as `0x${string}`;
 
   const { fromToken: fromTokenSymbol } = useSwapFormValues();
 
-  const fromToken = getTokenBySymbol(fromTokenSymbol, tokens);
+  const fromToken = getTokenBySymbol(fromTokenSymbol, fromTokens);
 
   const closeModal = () => {
     setIsApprovalModalOpen(false);

--- a/packages/frontend/src/hooks/useCullQueries.tsx
+++ b/packages/frontend/src/hooks/useCullQueries.tsx
@@ -7,11 +7,11 @@ import { useSwapFormValues } from './useSwapFormValues';
 const useCullQueries = (primaryKey: string) => {
   const queryClient = useQueryClient();
   const { fromToken: fromTokenSymbol, fromToken: toTokenSymbol, fromAmount } = useSwapFormValues();
-  const { tokens } = useTokens();
+  const { fromTokens, toTokens } = useTokens();
 
   useEffect(() => {
-    const fromToken = getTokenBySymbol(fromTokenSymbol, tokens);
-    const toToken = getTokenBySymbol(toTokenSymbol, tokens);
+    const fromToken = getTokenBySymbol(fromTokenSymbol, fromTokens);
+    const toToken = getTokenBySymbol(toTokenSymbol, toTokens);
 
     queryClient
       .invalidateQueries({

--- a/packages/frontend/src/hooks/useDefaultTokens.tsx
+++ b/packages/frontend/src/hooks/useDefaultTokens.tsx
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+import { useFormContext } from 'react-hook-form';
+import { useTokens } from 'src/hooks/useTokens';
+import { SwapFormKeyHelper } from 'src/providers/SwapFormProvider';
+
+const useDefaultTokens = () => {
+  const { setValue } = useFormContext();
+  const fromTokenKey = SwapFormKeyHelper.getTokenKey('from');
+  const toTokenKey = SwapFormKeyHelper.getTokenKey('to');
+  const { fromTokens, toTokens } = useTokens();
+
+  useEffect(() => {
+    if (fromTokens.length > 1) {
+      setValue(fromTokenKey, fromTokens[0].symbol);
+    }
+  }, [fromTokens, setValue]);
+
+  useEffect(() => {
+    if (toTokens.length > 1) {
+      setValue(toTokenKey, toTokens[1].symbol);
+    }
+  }, [toTokens, setValue]);
+};
+
+export { useDefaultTokens };

--- a/packages/frontend/src/hooks/useFetchTokens.tsx
+++ b/packages/frontend/src/hooks/useFetchTokens.tsx
@@ -1,0 +1,36 @@
+import { useQuery } from '@tanstack/react-query';
+import { showToast } from '@sifi/shared-ui';
+import { getOrderedTokenList } from 'src/utils/tokens';
+import { useSifi } from 'src/providers/SDKProvider';
+
+const useFetchTokens = (chainId: number) => {
+  const sifi = useSifi();
+
+  const { refetch } = useQuery(
+    ['tokens', chainId],
+    async () => {
+      const data = await sifi.getTokens(chainId);
+      return getOrderedTokenList(data);
+    },
+    { enabled: false }
+  );
+
+  const fetchTokens = async () => {
+    try {
+      const { data: tokensData } = await refetch();
+      if (tokensData) {
+        return tokensData;
+      }
+    } catch (error) {
+      showToast({
+        text: `Failed to fetch tokens for ${chainId}`,
+        type: 'error',
+      });
+    }
+    return [];
+  };
+
+  return { fetchTokens };
+};
+
+export { useFetchTokens };

--- a/packages/frontend/src/hooks/useMulticallTokenBalance.tsx
+++ b/packages/frontend/src/hooks/useMulticallTokenBalance.tsx
@@ -10,11 +10,14 @@ type UseMultiCallTokenBalance = {
   refetch: () => void;
 }
 
-const useMultiCallTokenBalance = (tokens: MulticallToken[]): UseMultiCallTokenBalance => {
+const useMultiCallTokenBalance = (
+  tokens: MulticallToken[],
+  chainId: number
+): UseMultiCallTokenBalance => {
   const { fromChain } = useSwapFormValues();
   const { address } = useAccount();
   const [addressBalanceMap, setAddressBalanceMap] = useState<BalanceMap | null>(null)
-  const publicClient = usePublicClient({ chainId: fromChain.id });
+  const publicClient = usePublicClient({ chainId });
 
   const balanceReadContracts = address?.startsWith('0x') ? tokens.map(token => ({
     address: token.address,

--- a/packages/frontend/src/hooks/useQuote.tsx
+++ b/packages/frontend/src/hooks/useQuote.tsx
@@ -14,9 +14,9 @@ const useQuote = () => {
   const sifi = useSifi();
   const { fromToken: fromTokenSymbol, toToken: toTokenSymbol, fromAmount } = useSwapFormValues();
   const { setValue } = useFormContext();
-  const { tokens } = useTokens();
-  const { fromChain } = useSwapFormValues();
-  const fromToken = getTokenBySymbol(fromTokenSymbol, tokens);
+  const { fromTokens, toTokens } = useTokens();
+  const fromToken = getTokenBySymbol(fromTokenSymbol, fromTokens);
+  const toToken = getTokenBySymbol(toTokenSymbol, toTokens);
   const toToken = getTokenBySymbol(toTokenSymbol, tokens);
   const isSameTokenPair = fromToken?.address === toToken?.address;
 

--- a/packages/frontend/src/hooks/useQuote.tsx
+++ b/packages/frontend/src/hooks/useQuote.tsx
@@ -12,12 +12,17 @@ import { useSwapFormValues } from './useSwapFormValues';
 
 const useQuote = () => {
   const sifi = useSifi();
-  const { fromToken: fromTokenSymbol, toToken: toTokenSymbol, fromAmount } = useSwapFormValues();
+  const {
+    fromToken: fromTokenSymbol,
+    toToken: toTokenSymbol,
+    fromAmount,
+    fromChain,
+    toChain,
+  } = useSwapFormValues();
   const { setValue } = useFormContext();
   const { fromTokens, toTokens } = useTokens();
   const fromToken = getTokenBySymbol(fromTokenSymbol, fromTokens);
   const toToken = getTokenBySymbol(toTokenSymbol, toTokens);
-  const toToken = getTokenBySymbol(toTokenSymbol, tokens);
   const isSameTokenPair = fromToken?.address === toToken?.address;
 
   const quoteRequest = {
@@ -28,7 +33,7 @@ const useQuote = () => {
       fromToken?.decimals || 0
     ).toString(),
     fromChain: fromChain.id,
-    toChain: fromChain.id,
+    toChain: toChain.id,
   };
 
   const handleSuccesfulQuoteFetch = (quote: Quote): void => {

--- a/packages/frontend/src/hooks/useSpendableBalance.ts
+++ b/packages/frontend/src/hooks/useSpendableBalance.ts
@@ -3,6 +3,7 @@ import { formatEther } from 'viem';
 import { Token } from '@sifi/sdk';
 import { ETH_CONTRACT_ADDRESS, SWAP_MAX_GAS_UNITS } from 'src/constants';
 import { useTokenBalance } from './useTokenBalance';
+import { useSwapFormValues } from './useSwapFormValues';
 
 type UseSpendableBalanceOptions = {
   token: Token | null;
@@ -10,9 +11,10 @@ type UseSpendableBalanceOptions = {
 
 const useSpendableBalance = ({ token }: UseSpendableBalanceOptions): string | undefined => {
   const { chain } = useNetwork();
+  const { fromChain } = useSwapFormValues();
   const { data: feeData } = useFeeData({ chainId: chain?.id, formatUnits: 'wei' });
   const isNativeToken = token?.address === ETH_CONTRACT_ADDRESS;
-  const { data: fromTokenBalanceData } = useTokenBalance(token);
+  const { data: fromTokenBalanceData } = useTokenBalance(token, fromChain.id);
 
   if (!feeData?.maxFeePerGas || !fromTokenBalanceData) {
     return '0';

--- a/packages/frontend/src/hooks/useTokenBalance.tsx
+++ b/packages/frontend/src/hooks/useTokenBalance.tsx
@@ -1,11 +1,9 @@
 import { useAccount, useBalance } from 'wagmi';
 import type { Token } from '@sifi/sdk';
 import { ETH_CONTRACT_ADDRESS } from 'src/constants';
-import { useSwapFormValues } from 'src/hooks/useSwapFormValues';
 
-const useTokenBalance = (token: Token | null) => {
+const useTokenBalance = (token: Token | null, chainId: number) => {
   const { address } = useAccount();
-  const { fromChain } = useSwapFormValues();
   const isFromEthereum = token?.address === ETH_CONTRACT_ADDRESS;
 
   return useBalance({
@@ -13,7 +11,7 @@ const useTokenBalance = (token: Token | null) => {
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     token: isFromEthereum ? undefined : (token?.address?.toLowerCase() as `0x${string}`),
     enabled: !!address && !!token?.address,
-    chainId: fromChain.id,
+    chainId,
   });
 };
 

--- a/packages/frontend/src/providers/SwapFormProvider.tsx
+++ b/packages/frontend/src/providers/SwapFormProvider.tsx
@@ -32,7 +32,7 @@ export const formDefaultValues = {
   [SwapFormKey.FromToken]: null,
   [SwapFormKey.ToAmount]: '',
   [SwapFormKey.ToAddress]: '',
-  [SwapFormKey.ToChain]: SUPPORTED_CHAINS[0],
+  [SwapFormKey.ToChain]: SUPPORTED_CHAINS[1],
   [SwapFormKey.ToToken]: null,
   [SwapFormKey.TokenSearchFilter]: '',
 };

--- a/packages/frontend/src/providers/SwapFormProvider.tsx
+++ b/packages/frontend/src/providers/SwapFormProvider.tsx
@@ -32,7 +32,7 @@ export const formDefaultValues = {
   [SwapFormKey.FromToken]: null,
   [SwapFormKey.ToAmount]: '',
   [SwapFormKey.ToAddress]: '',
-  [SwapFormKey.ToChain]: SUPPORTED_CHAINS[1],
+  [SwapFormKey.ToChain]: SUPPORTED_CHAINS[0],
   [SwapFormKey.ToToken]: null,
   [SwapFormKey.TokenSearchFilter]: '',
 };

--- a/packages/frontend/src/providers/TokensProvider.tsx
+++ b/packages/frontend/src/providers/TokensProvider.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { QueryObserverResult, useQuery } from '@tanstack/react-query';
 import {
   type FunctionComponent,
   type ReactNode,
@@ -7,27 +7,34 @@ import {
   useState,
   useMemo,
 } from 'react';
+import { showToast } from '@sifi/shared-ui';
 import { getOrderedTokenList } from 'src/utils/tokens';
 import { enableUnlistedTokenTrading } from 'src/utils/featureFlags';
 import { useSifi } from './SDKProvider';
 import type { Token } from '@sifi/sdk';
 import { useSwapFormValues } from 'src/hooks/useSwapFormValues';
+import { Chain } from 'viem';
+import { firstAndLast } from 'src/utils';
 
 const TokensContext = createContext<{
-  tokens: Token[];
+  fromTokens: Token[];
+  toTokens: Token[];
   isLoading: boolean;
-  fetchTokenByAddress?: (address: `0x${string}`) => Promise<void>;
+  fetchFromTokenByAddress?: (address: `0x${string}`) => Promise<void>;
+  fetchToTokenByAddress?: (address: `0x${string}`) => Promise<void>;
 }>({
-  tokens: [],
+  fromTokens: [],
+  toTokens: [],
   isLoading: true,
 });
 
 const TokensProvider: FunctionComponent<{ children: ReactNode }> = ({ children }) => {
   const sifi = useSifi();
-  const { fromChain } = useSwapFormValues();
-  const [tokens, setTokens] = useState<Token[]>([]);
+  const { fromChain, toChain } = useSwapFormValues();
+  const [fromTokens, setFromTokens] = useState<Token[]>([]);
+  const [toTokens, setToTokens] = useState<Token[]>([]);
 
-  const { refetch } = useQuery(
+  const { refetch: refetchFromTokens } = useQuery(
     ['tokens'],
     async () => {
       const data = await sifi.getTokens(fromChain.id);
@@ -37,36 +44,78 @@ const TokensProvider: FunctionComponent<{ children: ReactNode }> = ({ children }
     { enabled: false }
   );
 
-  const fetchTokens = async () => {
-    const { data: tokens } = await refetch();
+  const { refetch: refetchToTokens } = useQuery(
+    ['tokens'],
+    async () => {
+      const data = await sifi.getTokens(toChain.id);
 
-    if (tokens) {
-      setTokens(tokens);
+      return getOrderedTokenList(data);
+    },
+    { enabled: false }
+  );
+
+  const fetchTokens = async (
+    chain: Chain,
+    setTokens: React.Dispatch<React.SetStateAction<Token[]>>,
+    refetchTokens: () => Promise<QueryObserverResult<Token[], unknown>>
+  ) => {
+    try {
+      const { data: tokensData } = await refetchTokens();
+      if (tokensData) {
+        setTokens(tokensData);
+      }
+    } catch (error) {
+      showToast({
+        text: `Failed to fetch tokens for ${chain.name}`,
+        type: 'error',
+      });
     }
   };
 
-  const appendTokenFetchedByAddress = async (address: `0x${string}`) => {
+  const appendTokenFetchedByAddress = async (
+    chain: Chain,
+    address: string,
+    tokens: Token[],
+    setTokens: React.Dispatch<React.SetStateAction<Token[]>>
+  ) => {
     const token = tokens?.find(token => token.address.toLowerCase() === address.toLowerCase());
     if (!token) {
-      const fetchedToken = await sifi.getToken(fromChain.id, address);
-      if (fetchedToken) {
-        setTokens(tokens => [...tokens, fetchedToken]);
+      try {
+        const fetchedToken = await sifi.getToken(chain.id, address);
+        if (fetchedToken) {
+          setTokens(tokens => [...tokens, fetchedToken]);
+        }
+      } catch (error) {
+        showToast({
+          text: `Failed to fetch token with address ${firstAndLast(address)} for ${chain.name}`,
+          type: 'error',
+        });
       }
     }
   };
 
   useEffect(() => {
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    fetchTokens();
-  }, [fromChain]);
+    fetchTokens(fromChain, setFromTokens, refetchFromTokens);
+  }, [fromChain, setFromTokens, refetchFromTokens]);
+
+  useEffect(() => {
+    fetchTokens(toChain, setToTokens, refetchToTokens);
+  }, [toChain, setToTokens, refetchToTokens]);
 
   const value = useMemo(() => {
     return {
-      tokens: tokens || [],
-      isLoading: !tokens,
-      fetchTokenByAddress: enableUnlistedTokenTrading ? appendTokenFetchedByAddress : undefined,
+      fromTokens: fromTokens || [],
+      toTokens: toTokens || [],
+      isLoading: !fromTokens || !toTokens,
+      fetchFromTokenByAddress: enableUnlistedTokenTrading
+        ? (address: string) =>
+            appendTokenFetchedByAddress(fromChain, address, fromTokens, setFromTokens)
+        : undefined,
+      fetchToTokenByAddress: enableUnlistedTokenTrading
+        ? (address: string) => appendTokenFetchedByAddress(toChain, address, toTokens, setToTokens)
+        : undefined,
     };
-  }, [tokens]);
+  }, [fromTokens, toTokens]);
 
   return <TokensContext.Provider value={value}>{children}</TokensContext.Provider>;
 };

--- a/packages/frontend/src/utils/featureFlags.ts
+++ b/packages/frontend/src/utils/featureFlags.ts
@@ -1,2 +1,1 @@
 export const enableUnlistedTokenTrading = false;
-export const enableMultipleChains = true;

--- a/packages/frontend/src/utils/firstAndLast.ts
+++ b/packages/frontend/src/utils/firstAndLast.ts
@@ -1,0 +1,10 @@
+export const firstAndLast = (value: string, first = 4, last = 4, middle = '...') => {
+  if (value.length < first + last) {
+    return value;
+  }
+
+  const beginning = value.substring(0, first);
+  const end = value.substring(value.length - last);
+
+  return `${beginning}${middle}${end}`;
+};

--- a/packages/frontend/src/utils/firstAndLast.ts
+++ b/packages/frontend/src/utils/firstAndLast.ts
@@ -1,5 +1,5 @@
-export const firstAndLast = (value: string, first = 4, last = 4, middle = '...') => {
-  if (value.length < first + last) {
+const firstAndLast = (value: string, first = 4, last = 4, middle = '...') => {
+  if (value.length <= first + last) {
     return value;
   }
 
@@ -8,3 +8,5 @@ export const firstAndLast = (value: string, first = 4, last = 4, middle = '...')
 
   return `${beginning}${middle}${end}`;
 };
+
+export { firstAndLast };

--- a/packages/frontend/src/utils/index.ts
+++ b/packages/frontend/src/utils/index.ts
@@ -9,3 +9,4 @@ export * from './isValidTokenAmount';
 export * from './getViemErrorMessage';
 export * from './viemToEthersAdapters';
 export * from './uniswapPermitSigning';
+export * from './firstAndLast';

--- a/packages/frontend/src/utils/tests/firstAndLast.test.ts
+++ b/packages/frontend/src/utils/tests/firstAndLast.test.ts
@@ -1,0 +1,14 @@
+import { test, expect } from 'vitest';
+import { firstAndLast } from '../firstAndLast';
+
+test('should return the same string when length is less than or equal to first + last', () => {
+  expect(firstAndLast('12345678', 4, 4)).toBe('12345678');
+});
+
+test('should return a string with dots in the middle when length is greater than first + last', () => {
+  expect(firstAndLast('123456789', 4, 4)).toBe('1234...6789');
+});
+
+test('should return a string with custom middle when provided', () => {
+  expect(firstAndLast('123456789', 4, 4, '---')).toBe('1234---6789');
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,7 +54,7 @@ importers:
         specifier: ^2.0.12
         version: 2.0.13(react@18.2.0)
       '@sifi/sdk':
-        specifier: ^1.8.0
+        specifier: ^1.9.0
         version: link:../sdk
       '@sifi/shared-ui':
         specifier: ^1.7.5
@@ -11529,6 +11529,7 @@ packages:
 
   /eip1193-provider@1.0.1:
     resolution: {integrity: sha512-kSuqwQ26d7CzuS/t3yRXo2Su2cVH0QfvyKbr2H7Be7O5YDyIq4hQGCNTo5wRdP07bt+E2R/8nPCzey4ojBHf7g==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     dependencies:
       '@json-rpc-tools/provider': 1.7.6
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,7 +176,7 @@ importers:
         version: /@walletconnect/ethereum-provider@1.8.0
       '@walletconnect/ethereum-provider-v2':
         specifier: npm:@walletconnect/ethereum-provider@^2.4.6
-        version: /@walletconnect/ethereum-provider@2.4.6(@types/node@18.11.19)(react@18.2.0)(typescript@5.2.2)
+        version: /@walletconnect/ethereum-provider@2.10.0(@walletconnect/modal@2.6.1)
       autoprefixer:
         specifier: ^10.4.12
         version: 10.4.13(postcss@8.4.21)
@@ -219,6 +219,9 @@ importers:
       vite-plugin-svgr:
         specifier: 3.2.0
         version: 3.2.0(vite@4.1.3)
+      vitest:
+        specifier: ^0.34.6
+        version: 0.34.6
 
   packages/hardhat:
     devDependencies:
@@ -3943,6 +3946,13 @@ packages:
       '@sinclair/typebox': 0.25.23
     dev: true
 
+  /@jest/schemas@29.6.3:
+    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@sinclair/typebox': 0.27.8
+    dev: true
+
   /@jest/source-map@25.5.0:
     resolution: {integrity: sha512-eIGx0xN12yVpMcPaVpjXPnn3N30QGJCJQSkEDUt9x1fI1Gdvb07Ml6K5iN2hG7NmMP6FDmtPEssE3z6doOYUwQ==}
     engines: {node: '>= 8.3'}
@@ -5587,6 +5597,10 @@ packages:
     resolution: {integrity: sha512-VEB8ygeP42CFLWyAJhN5OklpxUliqdNEUcXb4xZ/CINqtYGTjL5ukluKdKzQ0iWdUxyQ7B0539PAUhHKrCNWSQ==}
     dev: true
 
+  /@sinclair/typebox@0.27.8:
+    resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
+    dev: true
+
   /@sindresorhus/is@4.6.0:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
@@ -7175,6 +7189,12 @@ packages:
       '@types/chai': 4.3.5
     dev: true
 
+  /@types/chai-subset@1.3.3:
+    resolution: {integrity: sha512-frBecisrNGz+F4T6bcc+NLeolfiojh5FxW2klu669+8BARtyQv2C/GkNW6FUodVe4BroGMP/wER/YDGc7rEllw==}
+    dependencies:
+      '@types/chai': 4.3.5
+    dev: true
+
   /@types/chai@4.3.5:
     resolution: {integrity: sha512-mEo1sAde+UCE6b2hxn332f1g1E8WfYRu6p5SvTKr2ZKC1f7gFJXk4h5PyGP9Dt6gCaG8y8XhwnXWC6Iy2cmBng==}
     dev: true
@@ -7932,6 +7952,44 @@ packages:
       - supports-color
     dev: true
 
+  /@vitest/expect@0.34.6:
+    resolution: {integrity: sha512-QUzKpUQRc1qC7qdGo7rMK3AkETI7w18gTCUrsNnyjjJKYiuUB9+TQK3QnR1unhCnWRC0AbKv2omLGQDF/mIjOw==}
+    dependencies:
+      '@vitest/spy': 0.34.6
+      '@vitest/utils': 0.34.6
+      chai: 4.3.10
+    dev: true
+
+  /@vitest/runner@0.34.6:
+    resolution: {integrity: sha512-1CUQgtJSLF47NnhN+F9X2ycxUP0kLHQ/JWvNHbeBfwW8CzEGgeskzNnHDyv1ieKTltuR6sdIHV+nmR6kPxQqzQ==}
+    dependencies:
+      '@vitest/utils': 0.34.6
+      p-limit: 4.0.0
+      pathe: 1.1.1
+    dev: true
+
+  /@vitest/snapshot@0.34.6:
+    resolution: {integrity: sha512-B3OZqYn6k4VaN011D+ve+AA4whM4QkcwcrwaKwAbyyvS/NB1hCWjFIBQxAQQSQir9/RtyAAGuq+4RJmbn2dH4w==}
+    dependencies:
+      magic-string: 0.30.3
+      pathe: 1.1.1
+      pretty-format: 29.7.0
+    dev: true
+
+  /@vitest/spy@0.34.6:
+    resolution: {integrity: sha512-xaCvneSaeBw/cz8ySmF7ZwGvL0lBjfvqc1LpQ/vcdHEvpLn3Ff1vAvjw+CoGn0802l++5L/pxb7whwcWAw+DUQ==}
+    dependencies:
+      tinyspy: 2.2.0
+    dev: true
+
+  /@vitest/utils@0.34.6:
+    resolution: {integrity: sha512-IG5aDD8S6zlvloDsnzHw0Ut5xczlF+kv2BOTo+iXfPr54Yhi5qbVOgGB1hZaVq4iJ4C/MZ2J0y15IlsV/ZcI0A==}
+    dependencies:
+      diff-sequences: 29.6.3
+      loupe: 2.3.6
+      pretty-format: 29.7.0
+    dev: true
+
   /@wagmi/chains@1.7.0(typescript@5.2.2):
     resolution: {integrity: sha512-TKVeHv0GqP5sV1yQ8BDGYToAFezPnCexbbBpeH14x7ywi5a1dDStPffpt9x+ytE6LJWkZ6pAMs/HNWXBQ5Nqmw==}
     peerDependencies:
@@ -8140,37 +8198,6 @@ packages:
       - bufferutil
       - lokijs
       - utf-8-validate
-    dev: false
-
-  /@walletconnect/core@2.4.6(@types/node@18.11.19)(typescript@5.2.2):
-    resolution: {integrity: sha512-IPjS3dZvLQ2ZjuVKpel6NHIoW1bkCayh5W8XFC7nhLj5GHou5Gy2FsGgGbRknvCEVWH85AlFKFAvLZCe+TJ2VA==}
-    dependencies:
-      '@walletconnect/heartbeat': 1.2.0(@types/node@18.11.19)(typescript@5.2.2)
-      '@walletconnect/jsonrpc-provider': 1.0.13
-      '@walletconnect/jsonrpc-utils': 1.0.8
-      '@walletconnect/jsonrpc-ws-connection': 1.0.13
-      '@walletconnect/keyvaluestorage': 1.0.2
-      '@walletconnect/logger': 2.0.1
-      '@walletconnect/relay-api': 1.0.9
-      '@walletconnect/relay-auth': 1.0.4
-      '@walletconnect/safe-json': 1.0.2
-      '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.4.6(@types/node@18.11.19)(typescript@5.2.2)
-      '@walletconnect/utils': 2.4.6(@types/node@18.11.19)(typescript@5.2.2)
-      events: 3.3.0
-      lodash.isequal: 4.5.0
-      pino: 7.11.0
-      uint8arrays: 3.1.0
-    transitivePeerDependencies:
-      - '@react-native-async-storage/async-storage'
-      - '@swc/core'
-      - '@swc/wasm'
-      - '@types/node'
-      - bufferutil
-      - lokijs
-      - typescript
-      - utf-8-validate
-    dev: true
 
   /@walletconnect/core@2.9.2:
     resolution: {integrity: sha512-VARMPAx8sIgodeyngDHbealP3B621PQqjqKsByFUTOep8ZI1/R/20zU+cmq6j9RCrL+kLKZcrZqeVzs8Z7OlqQ==}
@@ -8263,34 +8290,6 @@ packages:
       - encoding
       - lokijs
       - utf-8-validate
-    dev: false
-
-  /@walletconnect/ethereum-provider@2.4.6(@types/node@18.11.19)(react@18.2.0)(typescript@5.2.2):
-    resolution: {integrity: sha512-o7UJ7EBzFSTqNAwGcVpqNv5qqaFW6Vi3nOoXPHtcrwYew8TKAcW/OQFHPcm0LeKfE15OvVI+GMHnPBRZ2Ih2RA==}
-    dependencies:
-      '@walletconnect/jsonrpc-http-connection': 1.0.7
-      '@walletconnect/jsonrpc-provider': 1.0.13
-      '@walletconnect/jsonrpc-types': 1.0.3
-      '@walletconnect/jsonrpc-utils': 1.0.8
-      '@walletconnect/sign-client': 2.4.6(@types/node@18.11.19)(typescript@5.2.2)
-      '@walletconnect/types': 2.4.6(@types/node@18.11.19)(typescript@5.2.2)
-      '@walletconnect/universal-provider': 2.4.6(@types/node@18.11.19)(typescript@5.2.2)
-      '@walletconnect/utils': 2.4.6(@types/node@18.11.19)(typescript@5.2.2)
-      '@web3modal/standalone': 2.1.1(react@18.2.0)
-      events: 3.3.0
-    transitivePeerDependencies:
-      - '@react-native-async-storage/async-storage'
-      - '@swc/core'
-      - '@swc/wasm'
-      - '@types/node'
-      - bufferutil
-      - debug
-      - encoding
-      - lokijs
-      - react
-      - typescript
-      - utf-8-validate
-    dev: true
 
   /@walletconnect/ethereum-provider@2.9.2(@walletconnect/modal@2.6.1):
     resolution: {integrity: sha512-eO1dkhZffV1g7vpG19XUJTw09M/bwGUwwhy1mJ3AOPbOSbMPvwiCuRz2Kbtm1g9B0Jv15Dl+TvJ9vTgYF8zoZg==}
@@ -8324,29 +8323,12 @@ packages:
       keyvaluestorage-interface: 1.0.0
       tslib: 1.14.1
 
-  /@walletconnect/heartbeat@1.2.0(@types/node@18.11.19)(typescript@5.2.2):
-    resolution: {integrity: sha512-0vbzTa/ARrpmMmOD+bQMxPvFYKtOLQZObgZakrYr0aODiMOO71CmPVNV2eAqXnw9rMmcP+z91OybLeIFlwTjjA==}
-    dependencies:
-      '@walletconnect/events': 1.0.1
-      '@walletconnect/time': 1.0.2
-      chai: 4.3.7
-      mocha: 10.2.0
-      ts-node: 10.9.1(@types/node@18.11.19)(typescript@5.2.2)
-      tslib: 1.14.1
-    transitivePeerDependencies:
-      - '@swc/core'
-      - '@swc/wasm'
-      - '@types/node'
-      - typescript
-    dev: true
-
   /@walletconnect/heartbeat@1.2.1:
     resolution: {integrity: sha512-yVzws616xsDLJxuG/28FqtZ5rzrTA4gUjdEMTbWB5Y8V1XHRmqq4efAxCw5ie7WjbXFSUyBHaWlMR+2/CpQC5Q==}
     dependencies:
       '@walletconnect/events': 1.0.1
       '@walletconnect/time': 1.0.2
       tslib: 1.14.1
-    dev: false
 
   /@walletconnect/iso-crypto@1.8.0:
     resolution: {integrity: sha512-pWy19KCyitpfXb70hA73r9FcvklS+FvO9QUIttp3c2mfW8frxgYeRXfxLRCIQTkaYueRKvdqPjbyhPLam508XQ==}
@@ -8486,7 +8468,6 @@ packages:
       valtio: 1.11.0(react@18.2.0)
     transitivePeerDependencies:
       - react
-    dev: false
 
   /@walletconnect/modal-ui@2.6.1(react@18.2.0):
     resolution: {integrity: sha512-RFUOwDAMijSK8B7W3+KoLKaa1l+KEUG0LCrtHqaB0H0cLnhEGdLR+kdTdygw+W8+yYZbkM5tXBm7MlFbcuyitA==}
@@ -8497,7 +8478,6 @@ packages:
       qrcode: 1.5.3
     transitivePeerDependencies:
       - react
-    dev: false
 
   /@walletconnect/modal@2.6.1(react@18.2.0):
     resolution: {integrity: sha512-G84tSzdPKAFk1zimgV7JzIUFT5olZUVtI3GcOk77OeLYjlMfnDT23RVRHm5EyCrjkptnvpD0wQScXePOFd2Xcw==}
@@ -8506,7 +8486,6 @@ packages:
       '@walletconnect/modal-ui': 2.6.1(react@18.2.0)
     transitivePeerDependencies:
       - react
-    dev: false
 
   /@walletconnect/qrcode-modal@1.8.0:
     resolution: {integrity: sha512-BueaFefaAi8mawE45eUtztg3ZFbsAH4DDXh1UNwdUlsvFMjqcYzLUG0xZvDd6z2eOpbgDg2N3bl6gF0KONj1dg==}
@@ -8570,32 +8549,6 @@ packages:
       - bufferutil
       - lokijs
       - utf-8-validate
-    dev: false
-
-  /@walletconnect/sign-client@2.4.6(@types/node@18.11.19)(typescript@5.2.2):
-    resolution: {integrity: sha512-Dt5p4g105/1EFXFCTvdJiqtRGRgyWPzIJ8MSsTlYSoeJiTYwUC+mlBh4Y+Io/cxtc5hUuguaj0MyovIMiL4KkA==}
-    dependencies:
-      '@walletconnect/core': 2.4.6(@types/node@18.11.19)(typescript@5.2.2)
-      '@walletconnect/events': 1.0.1
-      '@walletconnect/heartbeat': 1.2.0(@types/node@18.11.19)(typescript@5.2.2)
-      '@walletconnect/jsonrpc-provider': 1.0.13
-      '@walletconnect/jsonrpc-utils': 1.0.8
-      '@walletconnect/logger': 2.0.1
-      '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.4.6(@types/node@18.11.19)(typescript@5.2.2)
-      '@walletconnect/utils': 2.4.6(@types/node@18.11.19)(typescript@5.2.2)
-      events: 3.3.0
-      pino: 7.11.0
-    transitivePeerDependencies:
-      - '@react-native-async-storage/async-storage'
-      - '@swc/core'
-      - '@swc/wasm'
-      - '@types/node'
-      - bufferutil
-      - lokijs
-      - typescript
-      - utf-8-validate
-    dev: true
 
   /@walletconnect/sign-client@2.9.2:
     resolution: {integrity: sha512-anRwnXKlR08lYllFMEarS01hp1gr6Q9XUgvacr749hoaC/AwGVlxYFdM8+MyYr3ozlA+2i599kjbK/mAebqdXg==}
@@ -8663,25 +8616,6 @@ packages:
     transitivePeerDependencies:
       - '@react-native-async-storage/async-storage'
       - lokijs
-    dev: false
-
-  /@walletconnect/types@2.4.6(@types/node@18.11.19)(typescript@5.2.2):
-    resolution: {integrity: sha512-0ck2VvTRT4pTMQbop2Dku8YuOdNhebyJlXjtHN4naFgu73rXiw7Yml4N4hKjV4cwJoOBepWD2f9Dvl9cDFQ/Wg==}
-    dependencies:
-      '@walletconnect/events': 1.0.1
-      '@walletconnect/heartbeat': 1.2.0(@types/node@18.11.19)(typescript@5.2.2)
-      '@walletconnect/jsonrpc-types': 1.0.3
-      '@walletconnect/keyvaluestorage': 1.0.2
-      '@walletconnect/logger': 2.0.1
-      events: 3.3.0
-    transitivePeerDependencies:
-      - '@react-native-async-storage/async-storage'
-      - '@swc/core'
-      - '@swc/wasm'
-      - '@types/node'
-      - lokijs
-      - typescript
-    dev: true
 
   /@walletconnect/types@2.9.2:
     resolution: {integrity: sha512-7Rdn30amnJEEal4hk83cdwHUuxI1SWQ+K7fFFHBMqkuHLGi3tpMY6kpyfDxnUScYEZXqgRps4Jo5qQgnRqVM7A==}
@@ -8715,34 +8649,6 @@ packages:
       - encoding
       - lokijs
       - utf-8-validate
-    dev: false
-
-  /@walletconnect/universal-provider@2.4.6(@types/node@18.11.19)(typescript@5.2.2):
-    resolution: {integrity: sha512-FvuCCoQ00kYK3M6wYpaK9goCTa8kK5DQPTrsXYeitfXcJccQHxJahpEzIadLc6sj5+uK06WuLGGSObfpjSG3IA==}
-    dependencies:
-      '@walletconnect/jsonrpc-http-connection': 1.0.7
-      '@walletconnect/jsonrpc-provider': 1.0.13
-      '@walletconnect/jsonrpc-types': 1.0.3
-      '@walletconnect/jsonrpc-utils': 1.0.8
-      '@walletconnect/logger': 2.0.1
-      '@walletconnect/sign-client': 2.4.6(@types/node@18.11.19)(typescript@5.2.2)
-      '@walletconnect/types': 2.4.6(@types/node@18.11.19)(typescript@5.2.2)
-      '@walletconnect/utils': 2.4.6(@types/node@18.11.19)(typescript@5.2.2)
-      eip1193-provider: 1.0.1
-      events: 3.3.0
-      pino: 7.11.0
-    transitivePeerDependencies:
-      - '@react-native-async-storage/async-storage'
-      - '@swc/core'
-      - '@swc/wasm'
-      - '@types/node'
-      - bufferutil
-      - debug
-      - encoding
-      - lokijs
-      - typescript
-      - utf-8-validate
-    dev: true
 
   /@walletconnect/universal-provider@2.9.2:
     resolution: {integrity: sha512-JmaolkO8D31UdRaQCHwlr8uIFUI5BYhBzqYFt54Mc6gbIa1tijGOmdyr6YhhFO70LPmS6gHIjljwOuEllmlrxw==}
@@ -8796,34 +8702,6 @@ packages:
     transitivePeerDependencies:
       - '@react-native-async-storage/async-storage'
       - lokijs
-    dev: false
-
-  /@walletconnect/utils@2.4.6(@types/node@18.11.19)(typescript@5.2.2):
-    resolution: {integrity: sha512-SowRdiR3TTGeb3ikMP7ucOafgmu58Nh1pCjCff2666gQjVzT9qO1Y9aJ7eS3g3URJtLGzYCEIYohnUYOidvpgA==}
-    dependencies:
-      '@stablelib/chacha20poly1305': 1.0.1
-      '@stablelib/hkdf': 1.0.1
-      '@stablelib/random': 1.0.2
-      '@stablelib/sha256': 1.0.1
-      '@stablelib/x25519': 1.0.3
-      '@walletconnect/jsonrpc-utils': 1.0.8
-      '@walletconnect/relay-api': 1.0.9
-      '@walletconnect/safe-json': 1.0.2
-      '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.4.6(@types/node@18.11.19)(typescript@5.2.2)
-      '@walletconnect/window-getters': 1.0.1
-      '@walletconnect/window-metadata': 1.0.1
-      detect-browser: 5.3.0
-      query-string: 7.1.1
-      uint8arrays: 3.1.0
-    transitivePeerDependencies:
-      - '@react-native-async-storage/async-storage'
-      - '@swc/core'
-      - '@swc/wasm'
-      - '@types/node'
-      - lokijs
-      - typescript
-    dev: true
 
   /@walletconnect/utils@2.9.2:
     resolution: {integrity: sha512-D44hwXET/8JhhIjqljY6qxSu7xXnlPrf63UN/Qfl98vDjWlYVcDl2+JIQRxD9GPastw0S8XZXdRq59XDXLuZBg==}
@@ -8867,36 +8745,6 @@ packages:
     dependencies:
       '@walletconnect/window-getters': 1.0.1
       tslib: 1.14.1
-
-  /@web3modal/core@2.1.1(react@18.2.0):
-    resolution: {integrity: sha512-GAZAvfkPHoX2/fghQmf+y36uDspk9wBJxG7qLPUNTHzvIfRoNHWbTt3iEvRdPmUZwbTGDn1jvz9z0uU67gvZdw==}
-    dependencies:
-      buffer: 6.0.3
-      valtio: 1.9.0(react@18.2.0)
-    transitivePeerDependencies:
-      - react
-    dev: true
-
-  /@web3modal/standalone@2.1.1(react@18.2.0):
-    resolution: {integrity: sha512-K06VkZqltLIBKpnLeM2oszRDSdLnwXJWCcItWEOkH4LDFQIiq8lSeLhcamuadRxRKF4ZyTSLHHJ5MFcMfZEHQQ==}
-    deprecated: This package has been deprecated in favor of @walletconnect/modal. Please read more at https://docs.walletconnect.com
-    dependencies:
-      '@web3modal/core': 2.1.1(react@18.2.0)
-      '@web3modal/ui': 2.1.1(react@18.2.0)
-    transitivePeerDependencies:
-      - react
-    dev: true
-
-  /@web3modal/ui@2.1.1(react@18.2.0):
-    resolution: {integrity: sha512-0jRDxgPc/peaE5KgqnzzriXhdVu5xNyCMP5Enqdpd77VkknJIs7h16MYKidxgFexieyHpCOssWySsryWcP2sXA==}
-    dependencies:
-      '@web3modal/core': 2.1.1(react@18.2.0)
-      lit: 2.6.1
-      motion: 10.15.5
-      qrcode: 1.5.1
-    transitivePeerDependencies:
-      - react
-    dev: true
 
   /@webassemblyjs/ast@1.11.6:
     resolution: {integrity: sha512-IN1xI7PwOvLPgjcf180gC1bqn3q/QaOCwYUahIOhbYUu8KA/3tw2RT/T0Gidi1l7Hhj5D/INhJxiICObqpMu4Q==}
@@ -10418,6 +10266,11 @@ packages:
       yargs-parser: 20.2.9
     dev: true
 
+  /cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+    dev: true
+
   /cache-base@1.0.1:
     resolution: {integrity: sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==}
     engines: {node: '>=0.10.0'}
@@ -10520,6 +10373,19 @@ packages:
       check-error: 1.0.2
     dev: true
 
+  /chai@4.3.10:
+    resolution: {integrity: sha512-0UXG04VuVbruMUYbJ6JctvH0YnC/4q3/AkT18q4NaITo91CUm0liMS9VqzT9vZhVQ/1eqPanMWjBM+Juhfb/9g==}
+    engines: {node: '>=4'}
+    dependencies:
+      assertion-error: 1.1.0
+      check-error: 1.0.3
+      deep-eql: 4.1.3
+      get-func-name: 2.0.2
+      loupe: 2.3.6
+      pathval: 1.1.1
+      type-detect: 4.0.8
+    dev: true
+
   /chai@4.3.7:
     resolution: {integrity: sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==}
     engines: {node: '>=4'}
@@ -10576,6 +10442,12 @@ packages:
 
   /check-error@1.0.2:
     resolution: {integrity: sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==}
+    dev: true
+
+  /check-error@1.0.3:
+    resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
+    dependencies:
+      get-func-name: 2.0.2
     dev: true
 
   /chokidar@3.3.0:
@@ -11414,6 +11286,11 @@ packages:
   /diff-sequences@25.2.6:
     resolution: {integrity: sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==}
     engines: {node: '>= 8.3'}
+    dev: true
+
+  /diff-sequences@29.6.3:
+    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dev: true
 
   /diff@3.5.0:
@@ -13492,6 +13369,10 @@ packages:
 
   /get-func-name@2.0.0:
     resolution: {integrity: sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==}
+    dev: true
+
+  /get-func-name@2.0.2:
+    resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
     dev: true
 
   /get-intrinsic@1.2.1:
@@ -15589,6 +15470,10 @@ packages:
     hasBin: true
     dev: true
 
+  /jsonc-parser@3.2.0:
+    resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
+    dev: true
+
   /jsonfile@2.4.0:
     resolution: {integrity: sha512-PKllAqbgLgxHaj8TElYymKCAgrASebJrWpTnEkOaTowt23VKXXN0sUeriJ+eh7y6ufb/CC5ap11pz71/cM0hUw==}
     optionalDependencies:
@@ -15772,21 +15657,12 @@ packages:
     dependencies:
       '@types/trusted-types': 2.0.3
 
-  /lit@2.6.1:
-    resolution: {integrity: sha512-DT87LD64f8acR7uVp7kZfhLRrHkfC/N4BVzAtnw9Yg8087mbBJ//qedwdwX0kzDbxgPccWRW6mFwGbRQIxy0pw==}
-    dependencies:
-      '@lit/reactive-element': 1.6.1
-      lit-element: 3.3.3
-      lit-html: 2.8.0
-    dev: true
-
   /lit@2.7.6:
     resolution: {integrity: sha512-1amFHA7t4VaaDe+vdQejSVBklwtH9svGoG6/dZi9JhxtJBBlqY5D1RV7iLUYY0trCqQc4NfhYYZilZiVHt7Hxg==}
     dependencies:
       '@lit/reactive-element': 1.6.1
       lit-element: 3.3.3
       lit-html: 2.8.0
-    dev: false
 
   /load-json-file@4.0.0:
     resolution: {integrity: sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==}
@@ -15810,6 +15686,11 @@ packages:
       big.js: 5.2.2
       emojis-list: 3.0.0
       json5: 2.2.3
+    dev: true
+
+  /local-pkg@0.4.3:
+    resolution: {integrity: sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==}
+    engines: {node: '>=14'}
     dev: true
 
   /locate-path@2.0.0:
@@ -16345,6 +16226,15 @@ packages:
     hasBin: true
     dev: true
 
+  /mlly@1.4.2:
+    resolution: {integrity: sha512-i/Ykufi2t1EZ6NaPLdfnZk2AX8cs0d+mTzVKuPfqPKPatxLApaBoxJQ9x1/uckXtrS/U5oisPMDkNs0yQTaBRg==}
+    dependencies:
+      acorn: 8.10.0
+      pathe: 1.1.1
+      pkg-types: 1.0.3
+      ufo: 1.3.1
+    dev: true
+
   /mnemonist@0.38.5:
     resolution: {integrity: sha512-bZTFT5rrPKtPJxj8KSV0WkPyNxl72vQepqqVUAW2ARUpUSF2qXMB6jZj7hW5/k7C1rtpzqbD/IIbJwLXUjCHeg==}
     dependencies:
@@ -16446,17 +16336,6 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /motion@10.15.5:
-    resolution: {integrity: sha512-ejP6KioN4pigTGxL93APzOnvtLklParL59UQB2T3HWXQBxFcIp5/7YXFmkgiA6pNKKzjvnLhnonRBN5iSFMnNw==}
-    dependencies:
-      '@motionone/animation': 10.15.1
-      '@motionone/dom': 10.16.2
-      '@motionone/svelte': 10.16.2
-      '@motionone/types': 10.15.1
-      '@motionone/utils': 10.15.1
-      '@motionone/vue': 10.16.2
-    dev: true
-
   /motion@10.16.2:
     resolution: {integrity: sha512-p+PurYqfUdcJZvtnmAqu5fJgV2kR0uLFQuBKtLeFVTrYEVllI99tiOTSefVNYuip9ELTEkepIIDftNdze76NAQ==}
     dependencies:
@@ -16466,7 +16345,6 @@ packages:
       '@motionone/types': 10.15.1
       '@motionone/utils': 10.15.1
       '@motionone/vue': 10.16.2
-    dev: false
 
   /mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -17067,6 +16945,13 @@ packages:
       yocto-queue: 0.1.0
     dev: true
 
+  /p-limit@4.0.0:
+    resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      yocto-queue: 1.0.0
+    dev: true
+
   /p-locate@2.0.0:
     resolution: {integrity: sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==}
     engines: {node: '>=4'}
@@ -17227,6 +17112,10 @@ packages:
     resolution: {integrity: sha512-ODbEPR0KKHqECXW1GoxdDb+AZvULmXjVPy4rt+pGo2+TnjJTIPJQSVS6N63n8T2Ip+syHhbn52OewKicV0373w==}
     dev: true
 
+  /pathe@1.1.1:
+    resolution: {integrity: sha512-d+RQGp0MAYTIaDBIMmOfMwz3E+LOZnxx1HZd5R18mmCZY0QBlK0LDZfPc8FW8Ed2DlvsuE6PRjroDY+wg4+j/Q==}
+    dev: true
+
   /pathval@1.1.1:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
     dev: true
@@ -17338,6 +17227,14 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       find-up: 5.0.0
+    dev: true
+
+  /pkg-types@1.0.3:
+    resolution: {integrity: sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==}
+    dependencies:
+      jsonc-parser: 3.2.0
+      mlly: 1.4.2
+      pathe: 1.1.1
     dev: true
 
   /pkg-up@3.1.0:
@@ -17545,6 +17442,15 @@ packages:
       react-is: 17.0.2
     dev: true
 
+  /pretty-format@29.7.0:
+    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/schemas': 29.6.3
+      ansi-styles: 5.2.0
+      react-is: 18.1.0
+    dev: true
+
   /pretty-hrtime@1.0.3:
     resolution: {integrity: sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A==}
     engines: {node: '>= 0.8'}
@@ -17627,13 +17533,8 @@ packages:
       ipaddr.js: 1.9.1
     dev: true
 
-  /proxy-compare@2.4.0:
-    resolution: {integrity: sha512-FD8KmQUQD6Mfpd0hywCOzcon/dbkFP8XBd9F1ycbKtvVsfv6TsFUKJ2eC0Iz2y+KzlkdT1Z8SY6ZSgm07zOyqg==}
-    dev: true
-
   /proxy-compare@2.5.1:
     resolution: {integrity: sha512-oyfc0Tx87Cpwva5ZXezSp5V9vht1c7dZBhvuV/y3ctkgMVUmiAGDVeeB0dKhGSyT0v1ZTEQYpe/RXlBVBNuCLA==}
-    dev: false
 
   /proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
@@ -17703,17 +17604,6 @@ packages:
       yargs: 13.3.2
     dev: true
 
-  /qrcode@1.5.1:
-    resolution: {integrity: sha512-nS8NJ1Z3md8uTjKtP+SGGhfqmTCs5flU/xR623oI0JX+Wepz9R8UrRVCTBTJm3qGw3rH6jJ6MUHjkDx15cxSSg==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
-    dependencies:
-      dijkstrajs: 1.0.2
-      encode-utf8: 1.0.3
-      pngjs: 5.0.0
-      yargs: 15.4.1
-    dev: true
-
   /qrcode@1.5.3:
     resolution: {integrity: sha512-puyri6ApkEHYiVl4CFzo1tDkAZ+ATcnbJrJ6RiBM1Fhctdn/ix9MTE3hRph33omisEbC/2fcfemsseiKgBPKZg==}
     engines: {node: '>=10.13.0'}
@@ -17723,7 +17613,6 @@ packages:
       encode-utf8: 1.0.3
       pngjs: 5.0.0
       yargs: 15.4.1
-    dev: false
 
   /qs@6.11.0:
     resolution: {integrity: sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==}
@@ -17755,16 +17644,6 @@ packages:
       strict-uri-encode: 2.0.0
     dev: false
 
-  /query-string@7.1.1:
-    resolution: {integrity: sha512-MplouLRDHBZSG9z7fpuAAcI7aAYjDLhtsiVZsevsfaHWDS2IDdORKbSd1kWUA+V4zyva/HZoSfpwnYMMQDhb0w==}
-    engines: {node: '>=6'}
-    dependencies:
-      decode-uri-component: 0.2.2
-      filter-obj: 1.1.0
-      split-on-first: 1.1.0
-      strict-uri-encode: 2.0.0
-    dev: true
-
   /query-string@7.1.3:
     resolution: {integrity: sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==}
     engines: {node: '>=6'}
@@ -17773,7 +17652,6 @@ packages:
       filter-obj: 1.1.0
       split-on-first: 1.1.0
       strict-uri-encode: 2.0.0
-    dev: false
 
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -18894,6 +18772,10 @@ packages:
       get-intrinsic: 1.2.1
       object-inspect: 1.12.3
 
+  /siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+    dev: true
+
   /signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
     dev: true
@@ -19234,6 +19116,10 @@ packages:
       escape-string-regexp: 2.0.0
     dev: true
 
+  /stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+    dev: true
+
   /stacktrace-parser@0.1.10:
     resolution: {integrity: sha512-KJP1OCML99+8fhOHxwwzyWrlUuVX5GQ0ZpJTd1DFXhdkrvg1szxfHhawXUZ3g9TkXORQd4/WG68jMlQZ2p8wlg==}
     engines: {node: '>=6'}
@@ -19252,6 +19138,10 @@ packages:
   /statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
+    dev: true
+
+  /std-env@3.4.3:
+    resolution: {integrity: sha512-f9aPhy8fYBuMN+sNfakZV18U39PbalgjXG3lLB9WkaYTxijru61wb57V9wxxNthXM5Sd88ETBWi29qLAsHO52Q==}
     dev: true
 
   /stealthy-require@1.1.1:
@@ -19499,6 +19389,12 @@ packages:
   /strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+    dev: true
+
+  /strip-literal@1.3.0:
+    resolution: {integrity: sha512-PugKzOsyXpArk0yWmUwqOZecSO0GH0bPoctLcqNDH9J04pVW3lflYE0ujElBGTloevcxF5MofAOZ7C5l2b+wLg==}
+    dependencies:
+      acorn: 8.10.0
     dev: true
 
   /superjson@1.12.2:
@@ -19862,6 +19758,20 @@ packages:
 
   /tiny-invariant@1.3.1:
     resolution: {integrity: sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==}
+
+  /tinybench@2.5.1:
+    resolution: {integrity: sha512-65NKvSuAVDP/n4CqH+a9w2kTlLReS9vhsAP06MWx+/89nMinJyB2icyl58RIcqCmIggpojIGeuJGhjU1aGMBSg==}
+    dev: true
+
+  /tinypool@0.7.0:
+    resolution: {integrity: sha512-zSYNUlYSMhJ6Zdou4cJwo/p7w5nmAH17GRfU/ui3ctvjXFErXXkruT4MWW6poDeXgCaIBlGLrfU6TbTXxyGMww==}
+    engines: {node: '>=14.0.0'}
+    dev: true
+
+  /tinyspy@2.2.0:
+    resolution: {integrity: sha512-d2eda04AN/cPOR89F7Xv5bK/jrQEhmcLFe6HFldoeO9AJtps+fqEnh486vnT/8y4bw38pSyxDcTCAq+Ks2aJTg==}
+    engines: {node: '>=14.0.0'}
+    dev: true
 
   /tmp@0.0.33:
     resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
@@ -20337,6 +20247,10 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /ufo@1.3.1:
+    resolution: {integrity: sha512-uY/99gMLIOlJPwATcMVYfqDSxUR9//AUcgZMzwfSTJPDKzA1S8mX4VLqa+fiAtveraQUBCz4FFcwVZBGbwBXIw==}
+    dev: true
+
   /uglify-js@3.17.4:
     resolution: {integrity: sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==}
     engines: {node: '>=0.8.0'}
@@ -20344,12 +20258,6 @@ packages:
     requiresBuild: true
     dev: true
     optional: true
-
-  /uint8arrays@3.1.0:
-    resolution: {integrity: sha512-ei5rfKtoRO8OyOIor2Rz5fhzjThwIHJZ3uyDPnDHTXbP0aMQ1RN/6AI5B5d9dBxJOU+BvOAk7ZQ1xphsX8Lrog==}
-    dependencies:
-      multiformats: 9.9.0
-    dev: true
 
   /uint8arrays@3.1.1:
     resolution: {integrity: sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==}
@@ -20648,21 +20556,6 @@ packages:
       proxy-compare: 2.5.1
       react: 18.2.0
       use-sync-external-store: 1.2.0(react@18.2.0)
-    dev: false
-
-  /valtio@1.9.0(react@18.2.0):
-    resolution: {integrity: sha512-mQLFsAlKbYascZygFQh6lXuDjU5WHLoeZ8He4HqMnWfasM96V6rDbeFkw1XeG54xycmDonr/Jb4xgviHtuySrA==}
-    engines: {node: '>=12.20.0'}
-    peerDependencies:
-      react: '>=16.8'
-    peerDependenciesMeta:
-      react:
-        optional: true
-    dependencies:
-      proxy-compare: 2.4.0
-      react: 18.2.0
-      use-sync-external-store: 1.2.0(react@18.2.0)
-    dev: true
 
   /vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -20701,6 +20594,27 @@ packages:
       - utf-8-validate
       - zod
     dev: false
+
+  /vite-node@0.34.6(@types/node@18.11.19):
+    resolution: {integrity: sha512-nlBMJ9x6n7/Amaz6F3zJ97EBwR2FkzhBRxF5e+jE6LA3yi6Wtc2lyTij1OnDMIr34v5g/tVQtsVAzhT0jc5ygA==}
+    engines: {node: '>=v14.18.0'}
+    hasBin: true
+    dependencies:
+      cac: 6.7.14
+      debug: 4.3.4(supports-color@8.1.1)
+      mlly: 1.4.2
+      pathe: 1.1.1
+      picocolors: 1.0.0
+      vite: 4.1.3(@types/node@18.11.19)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
 
   /vite-plugin-svgr@3.2.0(vite@4.1.3):
     resolution: {integrity: sha512-Uvq6niTvhqJU6ga78qLKBFJSDvxWhOnyfQSoKpDPMAGxJPo5S3+9hyjExE5YDj6Lpa4uaLkGc1cBgxXov+LjSw==}
@@ -20748,6 +20662,70 @@ packages:
       rollup: 3.17.2
     optionalDependencies:
       fsevents: 2.3.2
+    dev: true
+
+  /vitest@0.34.6:
+    resolution: {integrity: sha512-+5CALsOvbNKnS+ZHMXtuUC7nL8/7F1F2DnHGjSsszX8zCjWSSviphCb/NuS9Nzf4Q03KyyDRBAXhF/8lffME4Q==}
+    engines: {node: '>=v14.18.0'}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@vitest/browser': '*'
+      '@vitest/ui': '*'
+      happy-dom: '*'
+      jsdom: '*'
+      playwright: '*'
+      safaridriver: '*'
+      webdriverio: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+      playwright:
+        optional: true
+      safaridriver:
+        optional: true
+      webdriverio:
+        optional: true
+    dependencies:
+      '@types/chai': 4.3.5
+      '@types/chai-subset': 1.3.3
+      '@types/node': 18.11.19
+      '@vitest/expect': 0.34.6
+      '@vitest/runner': 0.34.6
+      '@vitest/snapshot': 0.34.6
+      '@vitest/spy': 0.34.6
+      '@vitest/utils': 0.34.6
+      acorn: 8.10.0
+      acorn-walk: 8.2.0
+      cac: 6.7.14
+      chai: 4.3.10
+      debug: 4.3.4(supports-color@8.1.1)
+      local-pkg: 0.4.3
+      magic-string: 0.30.3
+      pathe: 1.1.1
+      picocolors: 1.0.0
+      std-env: 3.4.3
+      strip-literal: 1.3.0
+      tinybench: 2.5.1
+      tinypool: 0.7.0
+      vite: 4.1.3(@types/node@18.11.19)
+      vite-node: 0.34.6(@types/node@18.11.19)
+      why-is-node-running: 2.2.2
+    transitivePeerDependencies:
+      - less
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
     dev: true
 
   /w3c-hr-time@1.0.2:
@@ -20963,6 +20941,15 @@ packages:
     hasBin: true
     dependencies:
       isexe: 2.0.0
+    dev: true
+
+  /why-is-node-running@2.2.2:
+    resolution: {integrity: sha512-6tSwToZxTOcotxHeA+qGCq1mVzKR3CwcJGmVcY+QE8SHy6TnpFnh8PAvPNHYr7EcuVeG0QSMxtYCuO1ta/G/oA==}
+    engines: {node: '>=8'}
+    hasBin: true
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
     dev: true
 
   /wide-align@1.1.3:
@@ -21318,6 +21305,11 @@ packages:
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+    dev: true
+
+  /yocto-queue@1.0.0:
+    resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
+    engines: {node: '>=12.20'}
     dev: true
 
   /zksync-web3@0.14.3(ethers@5.7.2):


### PR DESCRIPTION
Sets up the cross-chain jump, i.e. bridging anything to anything on the frontend. This is a big one, but everything appears to be working.

### Changes made

- Contains #267.
- Remove `enableMultiChains` flag [0485c4b](https://github.com/sideshiftfi/sifi/pull/264/commits/0485c4bbfa079cfa19827dd4485b24d47e534ccb)
- Upgrade @sifi/sdk to 1.9.0 [a8bce34](https://github.com/sideshiftfi/sifi/pull/264/commits/a8bce3477fb9edd4acc2722ac44c4eff9373c05c)
- Add an util for displaying first and last characters of a string [23ebaab](https://github.com/sideshiftfi/sifi/pull/264/commits/23ebaab682d9b35f2b0acc4cd8d3d55fda8be0e7)
- Renamed `NetworkSelector` to `HeaderChainSelector`. [9f93a7b](https://github.com/sideshiftfi/sifi/pull/264/commits/9f93a7b0f2b6ca0e190a84c800def69f3d25c893) We now have 2 very similar components for chain selection. In the future, we might further change the one in the header.
- Add the two `ChainSelector` components to the UI [0e27487](https://github.com/sideshiftfi/sifi/pull/264/commits/0e274874f6a811ff4faeb8255b805e21d5f99037)
- Change the default `toChain` to be different than the `fromChain`, so that users instantly see that we have bridge functionality. [f431449](https://github.com/sideshiftfi/sifi/pull/264/commits/f431449fa7a8317dd83c20d827d1966a8fe8b91c)
- Add the ability for `useTokenBalance` to fetch balances for any chain. [1cda5db](https://github.com/sideshiftfi/sifi/pull/264/commits/1cda5db6d030a43bb9fff08a64da9a596d95411c)
- Fetch tokens for both `fromChain` and `toChain` separately, and store them in state. Instead of a single `tokens` we now have `fromTokens` and `toTokens`. [8a1400f](https://github.com/sideshiftfi/sifi/pull/264/commits/8a1400f6f1e5c7c88db41886404bffa7b8d61f4b)
- Update `useQuote` so that it can fetch from any chain [e5ff6fd](https://github.com/sideshiftfi/sifi/pull/264/commits/e5ff6fd61adc37775b1cadce2fe2527831a2a36a)
- "Same token" limitations now has to apply for tokens on the same chain [fbd6ac9](https://github.com/sideshiftfi/sifi/pull/264/commits/fbd6ac9193e69f62b1478dc9efec9ff763fa000a)
- Balances in `TokenSelector` for different chains work via the updated multicall [2078137](https://github.com/sideshiftfi/sifi/pull/264/commits/2078137f14cdc9b2ab72c55bc5c69a2ee34fc4cc)
- Updated the explorer link to use `toChain` [dd0c5b8](https://github.com/sideshiftfi/sifi/pull/264/commits/dd0c5b846ebc854ef1d709053ece821dfd078bde)
- Updated the main heading to `Cross Chain Jump`. I think it sounds good. [ce2e798](https://github.com/sideshiftfi/sifi/pull/264/commits/ce2e798d4cee3c3cce378119d56fefc3dd037821)

### Additional notes
- We should display a toast for quote errors to inform the user.
- Arbitrum `0` balances don't show in ShiftInput for some reason.
- There are some other small bugs that we can fix in future PRs so this doesn't get any more bloated.

### Testing

Maybe time to set up E2E testing?

- [x] Network switching via the header switch works
- [x] Network switching via the other switches work
- [x] Balances get updated in ShiftInput after switch
- [x] Can get quote on same chain
- [x] Can get quote cross-chain (only USDC and USDT seem to work as `toChain`)
- [x] TokenSelector shows the correct tokens for both chains
- [x] TokenSelector shows the correct balances for both chains
- [ ] Approval flow works
- [x] Swap works cross chain
- [x] Balances update after swap
- [x] Works in MetaMask on mobile

### Screenshot
<img width="1571" alt="image" src="https://github.com/sideshiftfi/sifi/assets/128667801/eb76cec9-7082-470c-a57d-f028bd31e69a">
