### PR TITLE
refactor(frontend): add useSwapFormValues hook

### DIFF
--- a/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
+++ b/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useWatch, useForm, useFormContext } from 'react-hook-form';
+import { useForm, useFormContext } from 'react-hook-form';
 import { useAccount, useWalletClient, usePublicClient } from 'wagmi';
 import { showToast, ShiftInput } from '@sifi/shared-ui';
 import { useTokens } from 'src/hooks/useTokens';
@@ -21,6 +21,7 @@ import { useMultiCallTokenBalance } from 'src/hooks/useMulticallTokenBalance';
 import { usePermit2 } from 'src/hooks/usePermit2';
 import { parseUnits } from 'viem';
 import { useSelectedChain } from 'src/providers/SelectedChainProvider';
+import { useSwapFormValues } from 'src/hooks/useSwapFormValues';
 
 const CreateSwap = () => {
   useCullQueries('quote');
@@ -34,9 +35,7 @@ const CreateSwap = () => {
   const { balanceMap, refetch: refetchTokenBalances } = useMultiCallTokenBalance(
     tokens as MulticallToken[]
   );
-  const [fromTokenSymbol, toTokenSymbol, fromAmount] = useWatch({
-    name: [SwapFormKey.FromToken, SwapFormKey.ToToken, SwapFormKey.FromAmount],
-  });
+  const { fromToken: fromTokenSymbol, toToken: toTokenSymbol, fromAmount } = useSwapFormValues();
   const fromToken = getTokenBySymbol(fromTokenSymbol, tokens);
   const toToken = getTokenBySymbol(toTokenSymbol, tokens);
   const [isLoading, setIsLoading] = useState(false);
@@ -172,7 +171,7 @@ const CreateSwap = () => {
     if (fromToken) {
       setValue(SwapFormKey.FromAmount, '');
     }
-  }, [fromToken])
+  }, [fromToken]);
 
   return (
     <div className="m:w-full py-2 sm:max-w-md">

--- a/packages/frontend/src/components/CreateSwapButtons/ApproveButton.tsx
+++ b/packages/frontend/src/components/CreateSwapButtons/ApproveButton.tsx
@@ -1,11 +1,10 @@
 import { showToast } from '@sifi/shared-ui';
-import { useWatch } from 'react-hook-form';
 import { useApprove } from 'src/hooks/useApprove';
 import { useAllowance } from 'src/hooks/useAllowance';
-import { SwapFormKey } from 'src/providers/SwapFormProvider';
 import { ApprovalModal } from 'src/modals';
 import { Button } from '../Button';
 import { getViemErrorMessage } from 'src/utils';
+import { useSwapFormValues } from 'src/hooks/useSwapFormValues';
 
 const ApproveButton = () => {
   const {
@@ -16,9 +15,7 @@ const ApproveButton = () => {
     openModal,
   } = useApprove();
   const { refetch: refetchAllowance } = useAllowance();
-  const [fromTokenSymbol] = useWatch({
-    name: [SwapFormKey.FromToken],
-  });
+  const { fromToken: fromTokenSymbol } = useSwapFormValues();
 
   const handleClick = async () => {
     try {

--- a/packages/frontend/src/components/CreateSwapButtons/SwitchNetworkButton.tsx
+++ b/packages/frontend/src/components/CreateSwapButtons/SwitchNetworkButton.tsx
@@ -1,16 +1,13 @@
-import { useWatch } from 'react-hook-form';
 import { useSwitchNetwork } from 'wagmi';
 import { useTokens } from 'src/hooks/useTokens';
-import { SwapFormKey } from 'src/providers/SwapFormProvider';
 import { getTokenBySymbol } from 'src/utils';
 import { Button } from '../Button';
+import { useSwapFormValues } from 'src/hooks/useSwapFormValues';
 
 const SwitchNetworkButton = () => {
   const { switchNetwork, isLoading: isSwitchingNetwork } = useSwitchNetwork();
   const { tokens } = useTokens();
-  const [fromTokenSymbol] = useWatch({
-    name: [SwapFormKey.FromToken, SwapFormKey.ToToken, SwapFormKey.FromAmount],
-  });
+  const { fromToken: fromTokenSymbol } = useSwapFormValues();
   const fromToken = getTokenBySymbol(fromTokenSymbol, tokens);
 
   const handleSwitchNetwork = () => {

--- a/packages/frontend/src/hooks/useAllowance.tsx
+++ b/packages/frontend/src/hooks/useAllowance.tsx
@@ -1,11 +1,10 @@
 import { erc20ABI, useAccount, useContractRead } from 'wagmi';
 import { parseUnits } from 'viem';
 import { getTokenBySymbol } from 'src/utils';
-import { SwapFormKey } from 'src/providers/SwapFormProvider';
 import { ETH_CONTRACT_ADDRESS, MIN_ALLOWANCE } from 'src/constants';
-import { useWatch } from 'react-hook-form';
 import { useQuote } from './useQuote';
 import { useTokens } from './useTokens';
+import { useSwapFormValues } from './useSwapFormValues';
 
 const useAllowance = () => {
   const { quote, isFetching: isFetchingQuote } = useQuote();
@@ -14,9 +13,7 @@ const useAllowance = () => {
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const approveAddress = (quote?.permit2Address || quote?.approveAddress) as `0x${string}`;
 
-  const [fromTokenSymbol, fromAmount] = useWatch({
-    name: [SwapFormKey.FromToken, SwapFormKey.FromAmount],
-  });
+  const { fromToken: fromTokenSymbol, fromAmount } = useSwapFormValues();
 
   const fromToken = getTokenBySymbol(fromTokenSymbol, tokens);
 
@@ -40,8 +37,7 @@ const useAllowance = () => {
   // TODO: Display errors in a toast
 
   const fromAmountInWei = fromToken ? parseUnits(fromAmount || '0', fromToken.decimals) : BigInt(0);
-  const isAllowanceAboveFromAmount =
-    allowance !== undefined && allowance >= fromAmountInWei;
+  const isAllowanceAboveFromAmount = allowance !== undefined && allowance >= fromAmountInWei;
 
   return { allowance, isAllowanceAboveFromAmount, ...rest };
 };

--- a/packages/frontend/src/hooks/useApprove.tsx
+++ b/packages/frontend/src/hooks/useApprove.tsx
@@ -2,13 +2,12 @@ import { useState } from 'react';
 import { showToast } from '@sifi/shared-ui';
 import { useMutation } from '@tanstack/react-query';
 import { erc20ABI, usePublicClient, useWalletClient } from 'wagmi';
-import { useWatch } from 'react-hook-form';
 import { MAX_ALLOWANCE } from 'src/constants';
-import { SwapFormKey } from 'src/providers/SwapFormProvider';
 import { getEvmTxUrl, getTokenBySymbol } from 'src/utils';
 import { useSelectedChain } from 'src/providers/SelectedChainProvider';
 import { useQuote } from './useQuote';
 import { useTokens } from './useTokens';
+import { useSwapFormValues } from './useSwapFormValues';
 
 const useApprove = () => {
   const { selectedChain } = useSelectedChain();
@@ -20,9 +19,7 @@ const useApprove = () => {
   const { tokens } = useTokens();
   const approveAddress = (quote?.permit2Address || quote?.approveAddress) as `0x${string}`;
 
-  const [fromTokenSymbol] = useWatch({
-    name: [SwapFormKey.FromToken],
-  });
+  const { fromToken: fromTokenSymbol } = useSwapFormValues();
 
   const fromToken = getTokenBySymbol(fromTokenSymbol, tokens);
 

--- a/packages/frontend/src/hooks/useCullQueries.tsx
+++ b/packages/frontend/src/hooks/useCullQueries.tsx
@@ -1,15 +1,12 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { useEffect } from 'react';
-import { useWatch } from 'react-hook-form';
-import { SwapFormKey } from 'src/providers/SwapFormProvider';
 import { getQueryKey, getTokenBySymbol } from 'src/utils';
 import { useTokens } from './useTokens';
+import { useSwapFormValues } from './useSwapFormValues';
 
 const useCullQueries = (primaryKey: string) => {
   const queryClient = useQueryClient();
-  const [fromTokenSymbol, toTokenSymbol, fromAmount] = useWatch({
-    name: [SwapFormKey.FromToken, SwapFormKey.ToToken, SwapFormKey.FromAmount],
-  });
+  const { fromToken: fromTokenSymbol, fromToken: toTokenSymbol, fromAmount } = useSwapFormValues();
   const { tokens } = useTokens();
 
   useEffect(() => {

--- a/packages/frontend/src/hooks/useQuote.tsx
+++ b/packages/frontend/src/hooks/useQuote.tsx
@@ -2,19 +2,18 @@ import { useEffect } from 'react';
 import type { Quote } from '@sifi/sdk';
 import { parseUnits } from 'viem';
 import { useQuery } from '@tanstack/react-query';
-import { useFormContext, useWatch } from 'react-hook-form';
+import { useFormContext } from 'react-hook-form';
 import { useSifi } from 'src/providers/SDKProvider';
 import { SwapFormKey } from 'src/providers/SwapFormProvider';
 import { useSelectedChain } from 'src/providers/SelectedChainProvider';
 import { formatTokenAmount, getQueryKey, getTokenBySymbol, isValidTokenAmount } from 'src/utils';
 import { ETH_CONTRACT_ADDRESS } from 'src/constants';
 import { useTokens } from './useTokens';
+import { useSwapFormValues } from './useSwapFormValues';
 
 const useQuote = () => {
   const sifi = useSifi();
-  const [fromTokenSymbol, toTokenSymbol, fromAmount] = useWatch({
-    name: [SwapFormKey.FromToken, SwapFormKey.ToToken, SwapFormKey.FromAmount],
-  });
+  const { fromToken: fromTokenSymbol, toToken: toTokenSymbol, fromAmount } = useSwapFormValues();
   const { setValue } = useFormContext();
   const { tokens } = useTokens();
   const { selectedChain } = useSelectedChain();

--- a/packages/frontend/src/hooks/useSwapFormValues.tsx
+++ b/packages/frontend/src/hooks/useSwapFormValues.tsx
@@ -1,0 +1,11 @@
+import { useFormContext } from 'react-hook-form';
+import { SwapFormValues } from 'src/providers/SwapFormProvider';
+
+const useSwapFormValues = () => {
+  const { watch } = useFormContext<SwapFormValues>();
+  const formValues = watch();
+
+  return formValues;
+};
+
+export { useSwapFormValues };


### PR DESCRIPTION
Adds a hook so that we don't have to do the `SwapFormKeys` and `useWatch` dance in order to access values from the form state.

### Testing

- [x] Getting a quote works
- [x] Approval flow works
- [x] Swapping works
