### PR TITLE
feat(frontend): enable token trading by address

### DIFF
--- a/packages/frontend/src/providers/TokensProvider.tsx
+++ b/packages/frontend/src/providers/TokensProvider.tsx
@@ -52,7 +52,7 @@ const TokensProvider: FunctionComponent<{ children: ReactNode }> = ({ children }
     const token = tokens?.find(token => token.address.toLowerCase() === address.toLowerCase());
     if (!token) {
       try {
-        const fetchedToken = await sifi.getToken(chain.id, address);
+        const fetchedToken = await sifi.getToken(chain.id, address.toLowerCase());
         if (fetchedToken) {
           setTokens(tokens => [...tokens, fetchedToken]);
         }
@@ -78,7 +78,7 @@ const TokensProvider: FunctionComponent<{ children: ReactNode }> = ({ children }
         ? (address: string) => appendTokenFetchedByAddress(toChain, address, toTokens, setToTokens)
         : undefined,
     };
-  }, [fromTokens, toTokens]);
+  }, [fromTokens, toTokens, appendTokenFetchedByAddress, enableUnlistedTokenTrading]);
 
   return <TokensContext.Provider value={value}>{children}</TokensContext.Provider>;
 };

--- a/packages/frontend/src/utils/featureFlags.ts
+++ b/packages/frontend/src/utils/featureFlags.ts
@@ -1,1 +1,1 @@
-export const enableUnlistedTokenTrading = false;
+export const enableUnlistedTokenTrading = true;


### PR DESCRIPTION
### Changes Made

 - Flips token trading by address flag
 - Passes lowercased address to backend (broken otherwise, not certain why)

### Additional Notes
 - Icons do not load due to a Coingecko change  - requires a backend change (made an issue)

### Testing

 - [X] Search otherwise unlisted tokens by address on all supported chains
 - [X] Balance read on imported tokens
 - [X] Permit working with tokens by address
 - [X] Gas estimation does not fail on swap

### Checklist

Please tick the boxes that apply and provide additional details where necessary. Add or edit items as needed.

- [X] Changes are limited to a single goal.
- [X] Responsive design has been tested and looks good on all devices and screen sizes.
- [X] Changes have been tested on all major browsers (Chrome, Firefox, Safari).
- [X] The changes in Chromatic UI Tests all look good.
- [X] No accessibility issues have been introduced in Storybook's Accessibility tab.
- [X] The code has been optimized for performance.
