### PR TITLE
fix(frontend): handle multichain quote query culling

### DIFF
--- a/packages/frontend/src/hooks/useCullQueries.tsx
+++ b/packages/frontend/src/hooks/useCullQueries.tsx
@@ -17,7 +17,7 @@ const useCullQueries = (primaryKey: string) => {
       .invalidateQueries({
         predicate: query =>
           query.queryKey !==
-          getQueryKey(primaryKey, fromAmount, fromToken?.address, toToken?.address),
+          getQueryKey(primaryKey, fromAmount, fromToken, toToken),
       })
       .catch(error => console.log(error.message));
   }, [fromAmount, fromTokenSymbol, toTokenSymbol]);

--- a/packages/frontend/src/hooks/useQuote.tsx
+++ b/packages/frontend/src/hooks/useQuote.tsx
@@ -46,7 +46,7 @@ const useQuote = () => {
     Boolean(fromAmount) &&
     !isSameTokenPair &&
     isValidTokenAmount(fromAmount);
-  const queryKey = getQueryKey('quote', fromAmount, toToken?.address, fromToken?.address);
+  const queryKey = getQueryKey('quote', fromAmount, fromToken, toToken);
 
   // TODO: Quote gets fetched 4 times
   const {

--- a/packages/frontend/src/utils/queries.tsx
+++ b/packages/frontend/src/utils/queries.tsx
@@ -1,6 +1,16 @@
+import { type Token } from "@sifi/sdk";
+
 export const getQueryKey = (
   primaryKey: string,
   fromAmount?: string,
-  toTokenAddress?: string,
-  fromTokenAddress?: string
-) => [primaryKey, { fromAmount, toTokenAddress, fromTokenAddress }];
+  fromToken?: Token | null,
+  toToken?: Token | null,
+) => [
+  primaryKey, {
+    fromAmount,
+    toTokenAddress: toToken?.address,
+    fromTokenAddress: fromToken?.address,
+    toChainId: toToken?.chainId,
+    fromChainId: fromToken?.chainId,
+  }
+];


### PR DESCRIPTION
With multichain added, we need to add the chain ids as query keys to ensure we appropriately cull queries when switching chains.

We otherwise end up with quotes showing for incorrect pairs if a user switches networks and tokens quickly.

### Testing
  - Swapping chains and tokens quickly no longer results in quotes being shown for pairs other than the currently selected ones.