### PR TITLE
fix(frontend): always reset 'toAmount' value on input change

### DIFF
--- a/packages/frontend/src/hooks/useQuote.tsx
+++ b/packages/frontend/src/hooks/useQuote.tsx
@@ -57,14 +57,13 @@ const useQuote = () => {
     enabled,
     onSuccess: handleSuccesfulQuoteFetch,
     staleTime: 60_000,
+    retry: false,
   });
 
-  // To avoid showing the last qoute when the user clears fromAmount
+  // To avoid showing the last quote
   useEffect(() => {
-    if (!fromAmount) {
       setValue(SwapFormKey.ToAmount, '');
-    }
-  }, [fromAmount]);
+  }, [fromAmount, fromToken, toToken]);
 
   return {
     quote,


### PR DESCRIPTION
Bug reproduced by:

 - Selecting Arbitrum as destination network
 - Fetching quote for 44 USDC -> USDT 
 - Changing settle token to USDC (arb) (quote fails for me)
 - Quote for USDC -> USDT swap still appears, but shift button is disabled

### Changes Made

 - Always clear the 'toAmount' field when toToken, fromToken or toAmount changes

### Testing
 
 - Bug described above no longer occurs.

### Checklist

Please tick the boxes that apply and provide additional details where necessary. Add or edit items as needed.

- [X] Changes are limited to a single goal.
- [X] Responsive design has been tested and looks good on all devices and screen sizes.
- [X] Changes have been tested on all major browsers (Chrome, Firefox, Safari).
- [X] The changes in Chromatic UI Tests all look good.
- [X] No accessibility issues have been introduced in Storybook's Accessibility tab.
- [X] The code has been optimized for performance.
