### PR TITLE
feat(frontend): only retry once on failed quote

### DIFF
--- a/packages/frontend/src/hooks/useQuote.tsx
+++ b/packages/frontend/src/hooks/useQuote.tsx
@@ -57,7 +57,7 @@ const useQuote = () => {
     enabled,
     onSuccess: handleSuccesfulQuoteFetch,
     staleTime: 60_000,
-    retry: false,
+    retry: failureCount => failureCount < 1, // Retry once on failure
   });
 
   // To avoid showing the last quote


### PR DESCRIPTION
Only retry failed quotes once.

With multichain - users will have failing quotes more often, at least for now. Current we are retrying 4 times which leads to slow feedback and is frustrating.

If a quote has failed once it is very likely to fail again, retrying once is much faster and feels a lot better in testing.