### PR TITLE
feat(frontend): show usd value in shift input

### DIFF
--- a/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
+++ b/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
@@ -26,6 +26,7 @@ import { getTokenWithNetwork } from 'src/utils/getTokenWithNetwork';
 import { useDefaultTokens } from 'src/hooks/useDefaultTokens';
 import { useSyncTokenUrlParams } from 'src/hooks/useSyncTokenUrlParams';
 import { enableSwapInformation } from 'src/utils/featureFlags';
+import { useUsdValue } from 'src/hooks/useUsdValue';
 
 const CreateSwap = () => {
   useCullQueries('quote');
@@ -36,6 +37,7 @@ const CreateSwap = () => {
     fromToken: fromTokenSymbol,
     toToken: toTokenSymbol,
     fromAmount,
+    toAmount,
     fromChain,
     toChain,
   } = useSwapFormValues();
@@ -164,6 +166,16 @@ const CreateSwap = () => {
   const depositMax = isConnected ? spendableBalance : undefined;
   const selectedFromTokenWithNetwork = getTokenWithNetwork(selectedFromToken, fromChain);
   const selectedToTokenWithNetwork = getTokenWithNetwork(selectedToToken, toChain);
+  const fromUsdValue = useUsdValue({
+    address: fromToken?.address,
+    chainId: fromChain.id,
+    amount: fromAmount,
+  });
+  const toUsdValue = useUsdValue({
+    address: toToken?.address,
+    chainId: toChain?.id,
+    amount: toAmount,
+  });
 
   const resetTokenAmounts = () => {
     setValue(SwapFormKey.FromAmount, '');
@@ -202,6 +214,7 @@ const CreateSwap = () => {
                   formMethods={methods}
                   disabled={Boolean(isSameTokenPair)}
                   max={depositMax}
+                  usdValue={fromUsdValue}
                   hideLabel
                 />
               </div>
@@ -219,6 +232,7 @@ const CreateSwap = () => {
                 openSelector={() => openTokenSelector('to')}
                 formMethods={methods}
                 hideLabel
+                usdValue={toUsdValue}
               />
               <TokenSelector
                 balanceMap={tokenSelectorType === 'from' ? fromBalanceMap : toTokenBalanceMap}

--- a/packages/frontend/src/hooks/useUsdValue.ts
+++ b/packages/frontend/src/hooks/useUsdValue.ts
@@ -1,0 +1,31 @@
+import Big from 'big.js';
+import { useEffect, useState } from 'react';
+import { useSifi } from 'src/providers/SDKProvider';
+
+type UseUsdPriceOptions = {
+  address?: string | null;
+  chainId?: number | null;
+  amount?: string;
+};
+
+const useUsdValue = ({ address, chainId, amount }: UseUsdPriceOptions) => {
+  const [usdPrice, setUsdPrice] = useState<string>();
+  const sifi = useSifi();
+
+  const fetchUsdPrice = async () => {
+    if (!address || !chainId) return;
+
+    const response = await sifi.getUsdPrice(chainId, address);
+    setUsdPrice(response.usdPrice);
+  };
+
+  useEffect(() => {
+    fetchUsdPrice();
+  }, [address, chainId]);
+
+  if (!usdPrice || !amount) return '';
+
+  return Big(Number(usdPrice) * Number(amount)).toFixed(2);
+};
+
+export { useUsdValue };


### PR DESCRIPTION
### Changes Made

- Add `useUsdValue` hook to Frontend
- Show usd value for swap on both sides

### Additional Notes

⚠️ This PR uses #286 

### Screenshots/videos

<img width="442" alt="Screenshot 2023-10-06 at 11 08 23" src="https://github.com/sideshiftfi/sifi/assets/128688932/f43659e4-c864-489a-bcc8-22ff79feeaea">

### Checklist

Please tick the boxes that apply and provide additional details where necessary. Add or edit items as needed.

- [x] Changes are limited to a single goal.
- [x] Responsive design has been tested and looks good on all devices and screen sizes.
- [x] Changes have been tested on all major browsers (Chrome, Firefox, Safari).
- [x] The changes in Chromatic UI Tests all look good.
- [x] No accessibility issues have been introduced in Storybook's Accessibility tab.
- [x] The code has been optimized for performance.

### Related

Closes #136 
