### PR TITLE
feat(frontend): hide swap information, feature flag

### DIFF
--- a/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
+++ b/packages/frontend/src/components/CreateSwap/CreateSwap.tsx
@@ -25,6 +25,7 @@ import { ChainSelector } from 'src/components/ChainSelector/ChainSelector';
 import { getTokenWithNetwork } from 'src/utils/getTokenWithNetwork';
 import { useDefaultTokens } from 'src/hooks/useDefaultTokens';
 import { useSyncTokenUrlParams } from 'src/hooks/useSyncTokenUrlParams';
+import { enableSwapInformation } from 'src/utils/featureFlags';
 
 const CreateSwap = () => {
   useCullQueries('quote');
@@ -232,7 +233,7 @@ const CreateSwap = () => {
           </div>
         </form>
       </div>
-      <SwapInformation />
+      {enableSwapInformation && <SwapInformation />}
     </div>
   );
 };

--- a/packages/frontend/src/utils/featureFlags.ts
+++ b/packages/frontend/src/utils/featureFlags.ts
@@ -1,1 +1,2 @@
 export const enableUnlistedTokenTrading = true;
+export const enableSwapInformation = false;


### PR DESCRIPTION
Hides the `SwapInformation` component (current only displaying the incorrect gas estimate)