### PR TITLE
fix(frontend): fetch token by address

### DIFF
--- a/packages/frontend/src/providers/TokensProvider.tsx
+++ b/packages/frontend/src/providers/TokensProvider.tsx
@@ -36,12 +36,18 @@ const TokensProvider: FunctionComponent<{ children: ReactNode }> = ({ children }
   const { fetchTokens: fetchToTokens } = useFetchTokens(toChain.id);
 
   useEffect(() => {
-    fetchFromTokens().then(setFromTokens);
-  }, [fromChain, fetchFromTokens]);
+    const shouldRefetchFromTokens = fromChain.id !== fromTokens?.[0]?.chainId;
+    if (shouldRefetchFromTokens) {
+      fetchFromTokens().then(setFromTokens);
+    }
+  }, [fromChain]);
 
   useEffect(() => {
-    fetchToTokens().then(setToTokens);
-  }, [toChain, fetchToTokens]);
+    const shouldRefetchToTokens = toChain.id !== toTokens?.[0]?.chainId;
+    if (shouldRefetchToTokens) {
+      fetchToTokens().then(setToTokens);
+    }
+  }, [toChain]);
 
   const appendTokenFetchedByAddress = async (
     chain: Chain,


### PR DESCRIPTION
### Changes Made

 - Only re-fetches `toTokens` and `fromTokens` when the target chain id does not match the already fetched tokens.
 - Fixes an issue where a token fetched by id would immediately be replaced with re-fetched tokens.

### Screenshots/videos

Before:

https://github.com/sideshiftfi/sifi/assets/112887817/5c03e30b-a8ac-4b21-8318-41c91571aa74



After:


https://github.com/sideshiftfi/sifi/assets/112887817/6413e680-cc22-4e01-9c77-1401b574a002


### Testing

See videos

### Checklist

Please tick the boxes that apply and provide additional details where necessary. Add or edit items as needed.

- [X] Changes are limited to a single goal.
- [X] Responsive design has been tested and looks good on all devices and screen sizes.
- [X] Changes have been tested on all major browsers (Chrome, Firefox, Safari).
- [X] The changes in Chromatic UI Tests all look good.
- [X] No accessibility issues have been introduced in Storybook's Accessibility tab.
- [X] The code has been optimized for performance
