### PR TITLE
fix(frontend): insufficient balance label shows with sufficient balance

### DIFF
--- a/packages/frontend/src/components/CreateSwapButtons/CreateSwapButtons.tsx
+++ b/packages/frontend/src/components/CreateSwapButtons/CreateSwapButtons.tsx
@@ -38,17 +38,17 @@ const CreateSwapButtons = ({ isLoading }: { isLoading: boolean }) => {
   );
   const { data: fromBalance } = useTokenBalance(fromToken, fromChain.id);
   const fromAmountInWei = fromToken ? parseUnits(fromAmount || '0', fromToken.decimals) : BigInt(0);
-  const hasSufficientBalance = quote && fromBalance && fromBalance.value >= fromAmountInWei;
+  const hasSufficientBalance = fromBalance && fromBalance.value >= fromAmountInWei;
 
   const isShiftButtonLoading = isLoading || isFetchingAllowance || isFetchingQuote;
 
   const showApproveButton =
     Boolean(
       !!quote &&
-      allowance !== undefined &&
-      !isAllowanceAboveFromAmount &&
-      !isFromEthereum &&
-      hasSufficientBalance
+        allowance !== undefined &&
+        !isAllowanceAboveFromAmount &&
+        !isFromEthereum &&
+        hasSufficientBalance
     ) || isApproving;
 
   const isShiftButtonDisabled =
@@ -56,6 +56,7 @@ const CreateSwapButtons = ({ isLoading }: { isLoading: boolean }) => {
     showApproveButton ||
     !fromAmount ||
     !hasSufficientBalance ||
+    !quote ||
     !isValidTokenAmount(fromAmount);
 
   const getShiftButtonLabel = () => {


### PR DESCRIPTION
### Changes Made

- Remove the check if there's a quote for determining whether the user has sufficient balance. This caused the insufficient balance to occasionally show if a quote could not be fetched even though they might have enough balance

### Screenshots/videos

Example of a case where a quote could not be fetched:
<img width="550" alt="Screenshot 2023-10-12 at 11 08 52" src="https://github.com/sideshiftfi/sifi/assets/128688932/d1cc0e7e-26d5-41d5-ba64-a2d3ab39933b">

### Testing

- [x] Tested cases where no quote is available
- [x] Tested regular cases to ensure the label still shows in correct cases

### Checklist

Please tick the boxes that apply and provide additional details where necessary. Add or edit items as needed.

- [x] Changes are limited to a single goal.
- [x] Responsive design has been tested and looks good on all devices and screen sizes.
- [x] Changes have been tested on all major browsers (Chrome, Firefox, Safari).
- [x] The changes in Chromatic UI Tests all look good.
- [x] No accessibility issues have been introduced in Storybook's Accessibility tab.
- [x] The code has been optimized for performance.