### PR TITLE
fix(frontend): no quote fetched for cross-chain tokens with same address

### DIFF
--- a/packages/frontend/src/hooks/useQuote.tsx
+++ b/packages/frontend/src/hooks/useQuote.tsx
@@ -6,7 +6,13 @@ import { useQuery } from '@tanstack/react-query';
 import { useFormContext } from 'react-hook-form';
 import { useSifi } from 'src/providers/SDKProvider';
 import { SwapFormKey } from 'src/providers/SwapFormProvider';
-import { formatTokenAmount, getQueryKey, getTokenBySymbol, isValidTokenAmount, parseSifiErrorMessage } from 'src/utils';
+import {
+  formatTokenAmount,
+  getQueryKey,
+  getTokenBySymbol,
+  isValidTokenAmount,
+  parseSifiErrorMessage,
+} from 'src/utils';
 import { ETH_CONTRACT_ADDRESS } from 'src/constants';
 import { useTokens } from './useTokens';
 import { useSwapFormValues } from './useSwapFormValues';
@@ -24,7 +30,7 @@ const useQuote = () => {
   const { fromTokens, toTokens } = useTokens();
   const fromToken = getTokenBySymbol(fromTokenSymbol, fromTokens);
   const toToken = getTokenBySymbol(toTokenSymbol, toTokens);
-  const isSameTokenPair = fromToken?.address === toToken?.address;
+  const isSameTokenPair = fromToken?.address === toToken?.address && fromChain?.id === toChain?.id;
 
   const quoteRequest = {
     fromToken: fromToken?.address || ETH_CONTRACT_ADDRESS,
@@ -74,7 +80,7 @@ const useQuote = () => {
 
   // To avoid showing the last quote
   useEffect(() => {
-      setValue(SwapFormKey.ToAmount, '');
+    setValue(SwapFormKey.ToAmount, '');
   }, [fromAmount, fromToken, toToken]);
 
   return {


### PR DESCRIPTION
### Changes Made

- Add extra check to `isSameTokenPair` in `useQuote` for matching Chain IDs, so we can still request quotes for tokens with the same address as long as the chains are different

### Screenshots/videos

<img width="511" alt="Screenshot 2023-10-12 at 11 23 05" src="https://github.com/sideshiftfi/sifi/assets/128688932/413f6ec7-ced7-4a12-9fb3-82c90c0b1766">

### Testing

- Tested by requesting quotes for tokens with the same address on different chains

### Checklist

Please tick the boxes that apply and provide additional details where necessary. Add or edit items as needed.

- [x] Changes are limited to a single goal.
- [x] Responsive design has been tested and looks good on all devices and screen sizes.
- [x] Changes have been tested on all major browsers (Chrome, Firefox, Safari).
- [x] The changes in Chromatic UI Tests all look good.
- [x] No accessibility issues have been introduced in Storybook's Accessibility tab.
- [x] The code has been optimized for performance.
