### PR TITLE
fix(frontend): same token pair label on swap button

### DIFF
--- a/packages/frontend/src/components/CreateSwapButtons/CreateSwapButtons.tsx
+++ b/packages/frontend/src/components/CreateSwapButtons/CreateSwapButtons.tsx
@@ -45,10 +45,10 @@ const CreateSwapButtons = ({ isLoading }: { isLoading: boolean }) => {
   const showApproveButton =
     Boolean(
       !!quote &&
-      allowance !== undefined &&
-      !isAllowanceAboveFromAmount &&
-      !isFromEthereum &&
-      hasSufficientBalance
+        allowance !== undefined &&
+        !isAllowanceAboveFromAmount &&
+        !isFromEthereum &&
+        hasSufficientBalance
     ) || isApproving;
 
   const isShiftButtonDisabled =
@@ -59,7 +59,7 @@ const CreateSwapButtons = ({ isLoading }: { isLoading: boolean }) => {
     !isValidTokenAmount(fromAmount);
 
   const getShiftButtonLabel = () => {
-    if (fromToken?.address === toToken?.address && fromChain === toChain) {
+    if (fromToken?.address === toToken?.address && fromChain?.id === toChain?.id) {
       return 'Cannot shift same tokens';
     }
 


### PR DESCRIPTION
### Changes Made

- Fix chain equality check in `CreateSwapButton` used for displaying the same token pair label

### Screenshots/videos

Before:
<img width="485" alt="Screenshot 2023-10-12 at 11 26 58" src="https://github.com/sideshiftfi/sifi/assets/128688932/6fd3832c-c7e9-4714-afe3-7401f33b75fb">

After:
<img width="507" alt="Screenshot 2023-10-12 at 11 27 18" src="https://github.com/sideshiftfi/sifi/assets/128688932/782aede9-d4ad-4771-907b-a942809a6597">

### Checklist

Please tick the boxes that apply and provide additional details where necessary. Add or edit items as needed.

- [x] Changes are limited to a single goal.
- [x] Responsive design has been tested and looks good on all devices and screen sizes.
- [x] Changes have been tested on all major browsers (Chrome, Firefox, Safari).
- [x] The changes in Chromatic UI Tests all look good.
- [x] No accessibility issues have been introduced in Storybook's Accessibility tab.
- [x] The code has been optimized for performance.
