### PR TITLE
feat(frontend): filter bsc name

### DIFF
--- a/packages/frontend/src/utils/chains.ts
+++ b/packages/frontend/src/utils/chains.ts
@@ -26,7 +26,10 @@ const PRODUCTION_CHAINS: Chain[] = [
   arbitrum,
   avalanche,
   base,
-  bsc,
+  {
+    ...bsc,
+   name: 'BNB Chain'
+  },
   optimism,
   polygon,
 ];


### PR DESCRIPTION
### Changes Made

 - Special case for BSC chain name, allowing the name to be displayed in one line in network selector dropdowns.

### Additional Notes

 - This is the official name now, anyway: https://www.bnbchain.org/en
 
### Screenshots/videos
![image](https://github.com/sideshiftfi/sifi/assets/112887817/442cd07d-8531-41de-a176-ca085fd2a61d)
![image](https://github.com/sideshiftfi/sifi/assets/112887817/e70c95eb-d950-4352-bd92-c64455b9bab4)



### Testing

 - [X] No linebreaks in network selectors

### Checklist

Please tick the boxes that apply and provide additional details where necessary. Add or edit items as needed.

- [X] Changes are limited to a single goal.
- [X] Responsive design has been tested and looks good on all devices and screen sizes.
- [X] Changes have been tested on all major browsers (Chrome, Firefox, Safari).
- [X] The changes in Chromatic UI Tests all look good.
- [X] No accessibility issues have been introduced in Storybook's Accessibility tab.
- [X] The code has been optimized for performance.
